### PR TITLE
Fix warning function name

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -43,11 +43,11 @@ define tomcat::service (
   }
 
   if $java_home and ! $use_jsvc {
-    warn('$java_home has no affect unless $use_jsvc = true')
+    warning('$java_home has no affect unless $use_jsvc = true')
   }
 
   if $java_home and $start_command {
-    warn('$java_home is used in the $start_command, so this may not work as planned')
+    warning('$java_home is used in the $start_command, so this may not work as planned')
   }
 
   if $use_jsvc {


### PR DESCRIPTION
The service defined type was calling an unknown function 'warn' when it
should be 'warning'.  This commit resolves that.
