### PR TITLE
Call install_ methods only once in spec_helper_acceptance

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -3,13 +3,14 @@ require 'beaker-rspec/helpers/serverspec'
 
 
 unless ENV['RS_PROVISION'] == 'no'
+  if default.is_pe?
+    install_pe
+  else
+    install_puppet
+  end
+
   hosts.each do |host|
-    if host.is_pe?
-      install_pe
-    else
-      install_puppet
       on host, "mkdir -p #{host['distmoduledir']}"
-    end
   end
 end
 


### PR DESCRIPTION
install_puppet already installs puppet on every host. Remove code that
loops over the host array and calls install_puppet for each host in a
multi-host configuration.
