### PR TITLE
Updates for when installing from package

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,11 +386,11 @@ Specifies any attributes to remove from the Valve. Should be a hash of the forma
 
 #####`$catalina_home` 
 
-Specifies the root of the Tomcat installation.
+Specifies the root of the Tomcat installation. Only affects the instance installation if `$install_from_source` is true.
 
 #####`$catalina_base` 
 
-Specifies the base directory for the Tomcat installation.
+Specifies the base directory for the Tomcat installation. Only affects the instance installation if `$install_from_source` is true.
 
 #####`$install_from_source` 
 
@@ -503,6 +503,10 @@ Specifies the source to deploy the WAR from. Currently supports http(s)://, pupp
 ##Limitations
 
 This module only supports Tomcat installations on \*nix systems.  The `tomcat::config::server*` defines require augeas >= 1.0.0.
+
+###Multiple Instances
+
+If you are not installing Tomcat instances from source, depending on your packaging, multiple instances may not work.
 
 ##Development
 

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -64,6 +64,22 @@ describe 'tomcat::instance', :type => :define do
     )
     }
   end
+  context "install from package, set $catalina_base" do
+    let :facts do default_facts end
+    let :params do
+      {
+        :install_from_source => false,
+        :package_name        => 'tomcat',
+        :catalina_home       => '/opt/apache-tomcat',
+        :catalina_base       => '/opt/apache-tomcat/foo',
+      }
+    end
+
+    # This is supposed to generate a warning, but checking for that isn't
+    # currently supported in puppet-rspec, so just make sure it compiles
+    it { is_expected.to compile }
+    it { is_expected.to_not contain_file('/opt/apache-tomcat/foo') }
+  end
   describe "test install failures" do
     let :facts do default_facts end
     context "no source specified" do

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -57,6 +57,18 @@ describe 'tomcat::service', :type => :define do
     )
     }
   end
+  context 'using init with $catalina_base' do
+    let :params do
+      {
+        :use_init      => true,
+        :service_name  => 'tomcat',
+        :catalina_base => '/opt/apache-tomcat/foo',
+      }
+    end
+    # This should throw a warning, but that isn't supported by puppet-rspec
+    # so let's just make sure it compiles
+    it { is_expected.to compile }
+  end
   context 'set start/stop with init' do
     let :params do
       {


### PR DESCRIPTION
When installing from package or running the service with `$use_init =
true`, `$catalina_home` and `$catalina_base` have no affect. Making this
more explicit by adding a note in the docs and adding warnings.
