### PR TITLE
Allow one to set configuration when using tomcat package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The `war_source` can be a local file, puppet:/// file, http, or ftp.
 * `tomcat::config::server::valve`: Configures a [Valve](http://tomcat.apache.org/tomcat-8.0-doc/config/valve.html) element in $CATALINA_BASE/conf/server.xml.
 * `tomcat::instance`: Installs a Tomcat instance.
 * `tomcat::service`: Provides Tomcat service management.
-* `tomcat::setenv::entry`: Adds an entry to the setenv.sh script.
+* `tomcat::setenv::entry`: Adds an entry to the configuration file (ie. setenv.sh, /etc/sysconfig/tomcat, ...).
 * `tomcat::war`:  Manages the deployment of WAR files.
 
 ####Private Defined Types
@@ -462,9 +462,13 @@ Specifies the value of the parameter you're setting.
 
 Determines whether the fragment should be present or absent.
 
+#####`$config_file`
+
+Path to the configuration file to edit.
+
 #####`$base_path` 
 
-Sets the path to create the setenv.sh script under. Should be either '$catalina_base/bin' or '$catalina_home/bin'.
+Sets the path to create the setenv.sh script under. Should be either '$catalina_base/bin' or '$catalina_home/bin'. **Deprecated** This parameter is being deperecated, please use `$config_file`.
 
 #####`$parameter` 
 

--- a/manifests/setenv/entry.pp
+++ b/manifests/setenv/entry.pp
@@ -5,17 +5,27 @@
 # Parameters:
 # - $value is the value of the parameter you're setting
 # - $ensure whether the fragment should be present or absent.
-# - $base_path is the path to create the setenv.sh script under. Should be
-#   either $catalina_base/bin or $catalina_home/bin.
+# - $config_file is the path to the config file to edit
 # - $parameter is the parameter you're setting. Defaults to $name.
 # - $quote_char is the optional character to quote the value with.
+# - (Deprecated) $base_path is the path to create the setenv.sh script under. Should be
+#   either $catalina_base/bin or $catalina_home/bin.
 define tomcat::setenv::entry (
   $value,
-  $ensure     = 'present',
-  $base_path  = "${::tomcat::catalina_home}/bin",
-  $param      = $name,
-  $quote_char = undef,
+  $ensure      = 'present',
+  $config_file = "${::tomcat::catalina_home}/bin/setenv.sh",
+  $param       = $name,
+  $quote_char  = undef,
+  # Deprecated
+  $base_path   = '',
 ) {
+
+  if $base_path {
+    warning('The $base_path parameter is deprecated; please use $config_file instead')
+    $_config_file = "${base_path}/setenv.sh"
+  } else {
+    $_config_file = $config_file
+  }
 
   if ! $quote_char {
     $_quote_char = ''
@@ -23,8 +33,8 @@ define tomcat::setenv::entry (
     $_quote_char = $quote_char
   }
 
-  if ! defined(Concat["${base_path}/setenv.sh"]) {
-    concat { "${base_path}/setenv.sh":
+  if ! defined(Concat[$_config_file]) {
+    concat { $_config_file:
       owner => $::tomcat::user,
       group => $::tomcat::group,
     }
@@ -32,7 +42,7 @@ define tomcat::setenv::entry (
 
   concat::fragment { "setenv-${name}":
     ensure  => $ensure,
-    target  => "${base_path}/setenv.sh",
+    target  => $_config_file,
     content => inline_template('<%= @param %>=<%= @_quote_char %><%= @value %><%= @_quote_char %>'),
   }
 }

--- a/spec/defines/setenv/entry_spec.rb
+++ b/spec/defines/setenv/entry_spec.rb
@@ -59,4 +59,18 @@ describe 'tomcat::setenv::entry', :type => :define do
     })
     }
   end
+  context 'specific config_file' do
+    let :params do
+      {
+        'value'       => '/bin/true',
+        'config_file' => '/etc/sysconfig/tomcat',
+      }
+    end
+
+    it { is_expected.to contain_concat('/etc/sysconfig/tomcat') }
+    it { is_expected.to contain_concat__fragment('setenv-FOO').with({
+      'target' => '/etc/sysconfig/tomcat',
+    })
+    }
+  end
 end


### PR DESCRIPTION
When tomcat is installed from package (in EL), the scripts that
are run to launch tomcat do not source setenv.sh, hence the
`tomcat::setenv::entry` resource becomes useless for this specific
case.

In order to still be able to configure tomcat instance installed
from package, this PR creates a new resource `tomcat::config::entry`
that does exactly the same thing as `tomcat::setenv::entry` do but rely on
default configuration file based on the OS.
