### PR TITLE
Exporting setenv.sh entries to make them operational on Ubuntu 14.04

### DIFF
--- a/manifests/setenv/entry.pp
+++ b/manifests/setenv/entry.pp
@@ -43,6 +43,6 @@ define tomcat::setenv::entry (
   concat::fragment { "setenv-${name}":
     ensure  => $ensure,
     target  => $_config_file,
-    content => inline_template('<%= @param %>=<%= @_quote_char %><%= @value %><%= @_quote_char %>'),
+    content => inline_template('export <%= @param %>=<%= @_quote_char %><%= @value %><%= @_quote_char %>'),
   }
 }


### PR DESCRIPTION
As in the subject for this PR. Until this change setenv.sh had no effect on tomcat instance.
