### PR TITLE
MODULES-1295: Multiple connectors with same protocol

### DIFF
--- a/manifests/config/server/connector.pp
+++ b/manifests/config/server/connector.pp
@@ -37,17 +37,23 @@ define tomcat::config::server::connector (
     $_protocol = $name
   }
 
-  $base_path = "Server/Service[#attribute/name='${parent_service}']/Connector[#attribute/protocol='${_protocol}']"
+  $path = "Server/Service[#attribute/name='${parent_service}']"
 
   if $connector_ensure =~ /^(absent|false)$/ {
+    if ! $port {
+      $base_path = "${path}/Connector[#attribute/protocol='${_protocol}']"
+    } else {
+      $base_path = "${path}/Connector[#attribute/port='${port}']"
+    }
     $changes = "rm ${base_path}"
   } else {
     if ! $port {
-      fail('$port must be specified if you aren\'t removing the connector')
+      fail('$port must be specified unless $connector_ensure is set to \'absent\' or \'false\'')
     }
 
-    $_protocol_change = "set ${base_path}/#attribute/protocol ${_protocol}"
+    $base_path = "${path}/Connector[#attribute/port='${port}']"
     $_port = "set ${base_path}/#attribute/port ${port}"
+    $_protocol_change = "set ${base_path}/#attribute/protocol ${_protocol}"
     if ! empty($additional_attributes) {
       $_additional_attributes = prefix(join_keys_to_values($additional_attributes, ' '), "set ${base_path}/#attribute/")
     }
@@ -55,10 +61,10 @@ define tomcat::config::server::connector (
       $_attributes_to_remove = prefix(any2array($attributes_to_remove), "rm ${base_path}/#attribute/")
     }
 
-    $changes = delete_undef_values(flatten([$_protocol_change, $_port, $_additional_attributes, $_attributes_to_remove]))
+    $changes = delete_undef_values(flatten([$_port, $_protocol_change, $_additional_attributes, $_attributes_to_remove]))
   }
 
-  augeas { "server-${catalina_base}-${parent_service}-connector-${_protocol}":
+  augeas { "server-${catalina_base}-${parent_service}-connector-${port}":
     lens    => 'Xml.lns',
     incl    => "${catalina_base}/conf/server.xml",
     changes => $changes,

--- a/spec/defines/config/server/connector_spec.rb
+++ b/spec/defines/config/server/connector_spec.rb
@@ -31,17 +31,17 @@ describe 'tomcat::config::server::connector', :type => :define do
         ],
       }
     end
-    it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-Catalina2-connector-AJP/1.3').with(
+    it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-Catalina2-connector-8180').with(
       'lens'    => 'Xml.lns',
       'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
       'changes' => [
-        'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/protocol=\'AJP/1.3\']/#attribute/protocol AJP/1.3',
-        'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/protocol=\'AJP/1.3\']/#attribute/port 8180',
-        'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/protocol=\'AJP/1.3\']/#attribute/redirectPort 8543',
-        'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/protocol=\'AJP/1.3\']/#attribute/connectionTimeout 20000',
-        'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/protocol=\'AJP/1.3\']/#attribute/foo',
-        'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/protocol=\'AJP/1.3\']/#attribute/bar',
-        'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/protocol=\'AJP/1.3\']/#attribute/baz',
+        'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/port 8180',
+        'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/protocol AJP/1.3',
+        'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/redirectPort 8543',
+        'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/connectionTimeout 20000',
+        'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/foo',
+        'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/bar',
+        'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/baz',
       ],
     )
     }
@@ -51,9 +51,26 @@ describe 'tomcat::config::server::connector', :type => :define do
       {
         :catalina_base    => '/opt/apache-tomcat/test',
         :connector_ensure => 'absent',
+        :port             => '8180',
       }
     end
-    it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-Catalina-connector-HTTP/1.1').with(
+    it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-Catalina-connector-8180').with(
+      'lens'    => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
+      'changes' => [
+        'rm Server/Service[#attribute/name=\'Catalina\']/Connector[#attribute/port=\'8180\']',
+      ],
+    )
+    }
+  end
+  context 'remove connector no port' do
+    let :params do
+      {
+        :catalina_base    => '/opt/apache-tomcat/test',
+        :connector_ensure => 'absent',
+      }
+    end
+    it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-Catalina-connector-').with(
       'lens'    => 'Xml.lns',
       'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
       'changes' => [
@@ -62,11 +79,27 @@ describe 'tomcat::config::server::connector', :type => :define do
     )
     }
   end
+  context 'two connectors with same protocol' do
+    let :pre_condition do
+      'class { "tomcat": }
+      tomcat::config::server::connector { "temp":
+        protocol => "HTTP/1.1",
+        port     => "443",
+      }
+      '
+    end
+    let :params do
+      {
+        :port => '8180',
+      }
+    end
+    it { is_expected.to compile }
+  end
   describe 'failing tests' do
     context 'bad connector_ensure' do
       let :params do
         {
-          :connector_ensure => 'foo'
+          :connector_ensure => 'foo',
         }
       end
       it do
@@ -78,7 +111,7 @@ describe 'tomcat::config::server::connector', :type => :define do
     context 'bad additional_attributes' do
       let :params do
         {
-          :additional_attributes => 'foo'
+          :additional_attributes => 'foo',
         }
       end
       it do
@@ -96,7 +129,7 @@ describe 'tomcat::config::server::connector', :type => :define do
       it do
         expect {
           is_expected.to compile
-        }.to raise_error(Puppet::Error, /\$port must be specified/)
+        }.to raise_error(Puppet::Error)
       end
     end
     context 'old augeas' do


### PR DESCRIPTION
When tomcat::config::server::connector was initially designed the
assumption was made that the connector protocol would be unique for a
tomcat instance. It is much more reasonable to assume that the connector
port will be unique as you cannot actually bind two things to the same
port.
