### PR TITLE
update stdlib requirement to 4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ This module only supports Tomcat installations on \*nix systems.  The `tomcat::c
 
 ###Stdlib
 
-This module requires puppetlabs-stdlib >= 4.0. On Puppet Enterprise, this upgrade must be completed manually before this module can be installed. To update stdlib, run:
+This module requires puppetlabs-stdlib >= 4.2.0. On Puppet Enterprise, this upgrade must be completed manually before this module can be installed. To update stdlib, run:
 
 ```
 puppet module upgrade puppetlabs-stdlib

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,7 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":"4.x"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.2.0"},
     {"name":"puppetlabs-concat","version_requirement":">= 1.0.4"},
     {"name":"nanliu-staging","version_requirement":">= 0.4.1"}
   ]


### PR DESCRIPTION
puppetlabs-tomcat makes use of delete_undef_values(), which appeared in puppetlabs-stdlib 4.2.0.
