### PR TITLE
(FM-1912) Illegal version range in puppetlabs-tomcat requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -59,7 +59,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 3.3.x < 4.x"
+      "version_requirement": ">= 3.3.0 < 4.0.0"
     },
     {
       "name": "puppet",


### PR DESCRIPTION
Use correct version_requirement syntax for "pe" requirement
