### PR TITLE
Updated dependency module names in metadata.json to remove missing depen...

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -67,8 +67,8 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 4.2.0"},
-    {"name":"puppetlabs-concat","version_requirement":">= 1.0.4"},
-    {"name":"nanliu-staging","version_requirement":">= 0.4.1"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0"},
+    {"name":"puppetlabs/concat","version_requirement":">= 1.0.4"},
+    {"name":"nanliu/staging","version_requirement":">= 0.4.1"}
   ]
 }


### PR DESCRIPTION
...dency warnings on 'puppet module list'

Hopefully this PR makes sense, it will get rid of the warnings generated on 'puppet module list'

Warning: Missing dependency 'nanliu-staging':
  'puppetlabs-tomcat' (v1.0.1) requires 'nanliu-staging' (>= 0.0.0)
Warning: Missing dependency 'puppetlabs-concat':
  'puppetlabs-tomcat' (v1.0.1) requires 'puppetlabs-concat' (>= 0.0.0)
Warning: Missing dependency 'puppetlabs-stdlib':
  'puppetlabs-tomcat' (v1.0.1) requires 'puppetlabs-stdlib' (>= 0.0.0)
