### PR TITLE
Directory in opt should only be created if  is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
         - [tomcat::service](#tomcatservice)
         - [tomcat::setenv::entry](#tomcatsetenventry)
         - [tomcat::war](#tomcatwar)
-5. [Limitations - OS compatibility, etc.](#limitations)
-6. [Development - Guide for contributing to the module](#development)
+6. [Limitations - OS compatibility, etc.](#limitations)
+7. [Development - Guide for contributing to the module](#development)
     * [Contributing](#contributing)
     * [Tests](#running-tests)
 
@@ -55,10 +55,11 @@ puppet module upgrade puppetlabs-stdlib
 The simplest way to get Tomcat up and running with the tomcat module is to install the Tomcat package from EPEL,
 
 ```puppet
-class { 'tomcat': }
+class { 'tomcat':
+  install_from_source => false,
+}
 class { 'epel': }->
 tomcat::instance{ 'default':
-  install_from_source => false,
   package_name        => 'tomcat',
 }->
 ```
@@ -160,7 +161,7 @@ tomcat::config::server::connector { 'tomcat8-jsvc':
 }
 ```
 
-Then you would set `connector_ensure` to 'absent', and provide `notify` for the service.   
+Then you would set `connector_ensure` to 'absent', and provide `notify` for the service. 
 
 ```puppet 
 tomcat::config::server::connector { 'tomcat8-jsvc':
@@ -222,6 +223,10 @@ Sets the user to run Tomcat as.
 #####`$group`
 
 Sets the group to run Tomcat as.
+
+#####`$install_from_source` 
+
+Specifies whether or not to install from source. A Boolean that defaults to 'true'.
 
 #####`$manage_user`
 
@@ -437,7 +442,7 @@ Specifies the base directory for the Tomcat installation. Only affects the insta
 
 #####`$install_from_source` 
 
-Specifies whether or not to install from source. A Boolean that defaults to 'true'.
+Specifies whether or not to install from source.
 
 #####`$source_url` 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,12 +20,14 @@
 #   Boolean specifying whether or not to manage the group. Defaults to true.
 #
 class tomcat (
-  $catalina_home = $::tomcat::params::catalina_home,
-  $user          = $::tomcat::params::user,
-  $group         = $::tomcat::params::group,
-  $manage_user   = true,
-  $manage_group  = true,
+  $catalina_home       = $::tomcat::params::catalina_home,
+  $user                = $::tomcat::params::user,
+  $group               = $::tomcat::params::group,
+  $install_from_source = true,
+  $manage_user         = true,
+  $manage_group        = true,
 ) inherits ::tomcat::params {
+  validate_bool($install_from_source)
   validate_bool($manage_user)
   validate_bool($manage_group)
 
@@ -36,10 +38,12 @@ class tomcat (
     default: { }
   }
 
-  file { $catalina_home:
-    ensure => directory,
-    owner  => $user,
-    group  => $group,
+  if $install_from_source {
+    file { $catalina_home:
+      ensure => directory,
+      owner  => $user,
+      group  => $group,
+    }
   }
 
   if $manage_user {

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -20,7 +20,7 @@
 define tomcat::instance (
   $catalina_home          = undef,
   $catalina_base          = undef,
-  $install_from_source    = true,
+  $install_from_source    = $::tomcat::install_from_source,
   $source_url             = undef,
   $source_strip_first_dir = undef,
   $package_ensure         = undef,

--- a/spec/classes/tomcat_spec.rb
+++ b/spec/classes/tomcat_spec.rb
@@ -25,6 +25,20 @@ describe 'tomcat', :type => :class do
     }
   end
 
+  context "not installing from source" do
+    let :facts do
+      {
+        :osfamily => 'Debian'
+      }
+    end
+    let :params do
+      {
+        :install_from_source => false,
+      }
+    end
+    it { is_expected.not_to contain_file("/opt/apache-tomcat") }
+  end
+
   context "not managing user/group" do
     let :facts do
       {


### PR DESCRIPTION
I think that $catalina_home should only be created if tomcat is build from source.

When installing from package, it create an useless directory.
