### PR TITLE
MODULES-1478: Add a $purge_connectors parameter.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    concat: "git://github.com/puppetlabs/puppetlabs-concat.git"
-    staging: "git://github.com/nanliu/puppet-staging.git"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    concat: "https://github.com/puppetlabs/puppetlabs-concat.git"
+    staging: "https://github.com/nanliu/puppet-staging.git"
   symlinks:
     tomcat: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -228,6 +228,14 @@ Sets the group to run Tomcat as.
 
 Specifies whether or not to install from source. A Boolean that defaults to 'true'.
 
+#####`$purge_connectors`
+
+Specifies whether or not to purge existing Connector elements from server.xml. 
+
+For example, if you specify an HTTP connector element using ```tomcat::instance::connector``` and ```purge_connectors``` is set to ```true``` then existing HTTP connectors will be removed and only the HTTP connector you have specified will remain once the module has been applied.
+
+This is useful if you want to change the ports of existing connectors instead of adding additional connectors. Boolean that defaults to 'false'.
+
 #####`$manage_user`
 
 Specifies whether or not to manage the user. Boolean that defaults to 'true'.

--- a/manifests/config/server/connector.pp
+++ b/manifests/config/server/connector.pp
@@ -23,6 +23,7 @@ define tomcat::config::server::connector (
   $parent_service        = 'Catalina',
   $additional_attributes = {},
   $attributes_to_remove  = [],
+  $purge_connectors      = $::tomcat::purge_connectors,
 ) {
   if versioncmp($::augeasversion, '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
@@ -30,6 +31,7 @@ define tomcat::config::server::connector (
 
   validate_re($connector_ensure, '^(present|absent|true|false)$')
   validate_hash($additional_attributes)
+  validate_bool($purge_connectors)
 
   if $protocol {
     $_protocol = $protocol
@@ -38,6 +40,14 @@ define tomcat::config::server::connector (
   }
 
   $path = "Server/Service[#attribute/name='${parent_service}']"
+
+  if $purge_connectors {
+    $_purge_connectors = "rm Server//Connector[#attribute/protocol='${_protocol}']"
+  }
+
+  if $purge_connectors and ($connector_ensure =~ /^(absent|false)$/) {
+    fail('$connector_ensure must be set to \'true\' or \'present\' to use $purge_connectors')
+  }
 
   if $connector_ensure =~ /^(absent|false)$/ {
     if ! $port {
@@ -65,7 +75,7 @@ define tomcat::config::server::connector (
       $_attributes_to_remove = undef
     }
 
-    $changes = delete_undef_values(flatten([$_port, $_protocol_change, $_additional_attributes, $_attributes_to_remove]))
+    $changes = delete_undef_values(flatten([ $_purge_connectors, $_port, $_protocol_change, $_additional_attributes, $_attributes_to_remove ]))
   }
 
   augeas { "server-${catalina_base}-${parent_service}-connector-${port}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,10 +24,12 @@ class tomcat (
   $user                = $::tomcat::params::user,
   $group               = $::tomcat::params::group,
   $install_from_source = true,
+  $purge_connectors    = false,
   $manage_user         = true,
   $manage_group        = true,
 ) inherits ::tomcat::params {
   validate_bool($install_from_source)
+  validate_bool($purge_connectors)
   validate_bool($manage_user)
   validate_bool($manage_group)
 

--- a/spec/defines/config/server/connector_spec.rb
+++ b/spec/defines/config/server/connector_spec.rb
@@ -46,6 +46,42 @@ describe 'tomcat::config::server::connector', :type => :define do
     )
     }
   end
+  context 'set all the things with purge_connectors' do
+    let :params do
+      {
+        :port                  => '8180',
+        :catalina_base         => '/opt/apache-tomcat/test',
+        :protocol              => 'AJP/1.3',
+        :purge_connectors      => true,
+        :parent_service        => 'Catalina2',
+        :additional_attributes => {
+          'redirectPort'      => '8543',
+          'connectionTimeout' => '20000',
+        },
+        :attributes_to_remove  => [
+          'foo',
+          'bar',
+          'baz'
+        ],
+      }
+    end
+    it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-Catalina2-connector-8180'
+).with(
+      'lens'    => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
+      'changes' => [
+        'rm Server//Connector[#attribute/protocol=\'AJP/1.3\']',
+        'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/port 8180',
+        'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/protocol AJP/1.3',
+        'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/redirectPort 8543',
+        'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/connectionTimeout 20000',
+        'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/foo',
+        'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/bar',
+        'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/baz',
+      ],
+    )
+    }
+  end
   context 'remove connector' do
     let :params do
       {
@@ -78,6 +114,20 @@ describe 'tomcat::config::server::connector', :type => :define do
       ],
     )
     }
+  end
+  context 'remove connector with purge_connectors' do
+    let :params do
+      {
+        :catalina_base    => 'opt/apache-tomcat/test',
+        :connector_ensure => 'absent',
+        :purge_connectors => true,
+      }
+    end
+    it do
+      expect {
+        should compile
+      }.to raise_error(Puppet::Error, /\$connector_ensure must be set to 'true' or 'present' to use \$purge_connectors/)
+    end
   end
   context 'two connectors with same protocol' do
     let :pre_condition do


### PR DESCRIPTION
See MODULES-1478.

Basically the way that this module adds additional Connector elements seems very un-Puppet-like.

This PR adds a parameter called $purge_connectors which removes all existing connectors for a given protocol so that if you define a single HTTP connector on port 8140 then that's the only HTTP connector you will have after the module has been applied. I think this is what most users will expect and want.

I've set it to false by default so that it's not a breaking change.
