### PR TITLE
(FM-2010) Tomcat download mirrors are flaky (tests)

### DIFF
--- a/spec/acceptance/acceptance_1_spec.rb
+++ b/spec/acceptance/acceptance_1_spec.rb
@@ -13,16 +13,6 @@ confine_array = [
 stop_test = false
 stop_test = true if UNSUPPORTED_PLATFORMS.any?{ |up| fact('osfamily') == up} || confine_array.any?
 
-tcat_version = String.new
-shell('curl -k http://tomcat.apache.org/download-80.cgi?Preferred=http%3A%2F%2Fmirror.nexcess.net%2Fapache%2F', :acceptable_exit_codes => 0) do |r|
-  /apache-tomcat-(.{4,7}).tar.gz/.match(r.stdout).to_a.uniq.each do |m|
-    if m.length < 7
-      tcat_version = m
-      break
-    end
-  end
-end
-
 describe 'Acceptance case one', :unless => stop_test do
 
   context 'Initial install Tomcat and verification' do
@@ -39,7 +29,7 @@ describe 'Acceptance case one', :unless => stop_test do
       }
 
       tomcat::instance { 'tomcat_one':
-        source_url    => "http://mirror.nexcess.net/apache/tomcat/tomcat-8/v#{tcat_version}/bin/apache-tomcat-#{tcat_version}.tar.gz",
+        source_url    => '#{TOMCAT8_RECENT_SOURCE}',
         catalina_base => '/opt/apache-tomcat/tomcat8-jsvc',
       }->
       staging::extract { 'commons-daemon-native.tar.gz':
@@ -91,7 +81,7 @@ describe 'Acceptance case one', :unless => stop_test do
       }->
       tomcat::war { 'war_one.war':
         catalina_base => '/opt/apache-tomcat/tomcat8-jsvc',
-        war_source    => 'https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war',
+        war_source    => '#{SAMPLE_WAR}',
       }->
       tomcat::setenv::entry { 'JAVA_HOME':
         base_path => '/opt/apache-tomcat/tomcat8-jsvc/bin',
@@ -165,7 +155,7 @@ describe 'Acceptance case one', :unless => stop_test do
       class{ 'tomcat':}
       tomcat::war { 'war_one.war':
         catalina_base => '/opt/apache-tomcat/tomcat8-jsvc',
-        war_source => 'https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war',
+        war_source => '#{SAMPLE_WAR}',
         war_ensure => 'false',
       }
       EOS

--- a/spec/acceptance/acceptance_2_spec.rb
+++ b/spec/acceptance/acceptance_2_spec.rb
@@ -2,16 +2,6 @@ require 'spec_helper_acceptance'
 
 stop_test = true if UNSUPPORTED_PLATFORMS.any?{ |up| fact('osfamily') == up}
 
-tcat_version = String.new
-shell('curl -k http://tomcat.apache.org/download-60.cgi?Preferred=http%3A%2F%2Fmirror.symnds.com%2Fsoftware%2FApache%2F', :acceptable_exit_codes => 0) do |r|
-  /apache-tomcat-(.{4,7}).tar.gz/.match(r.stdout).to_a.uniq.each do |m|
-    if m.length < 7
-      tcat_version = m
-      break
-    end
-  end
-end
-
 describe 'Two different instances of Tomcat 6 in the same manifest', :unless => stop_test do
 
   context 'Initial install Tomcat and verification' do
@@ -23,7 +13,7 @@ describe 'Two different instances of Tomcat 6 in the same manifest', :unless => 
       class { 'tomcat':}
       class { 'java':}
       tomcat::instance { 'tomcat6':
-        source_url => 'http://mirror.symnds.com/software/Apache/tomcat/tomcat-6/v#{tcat_version}/bin/apache-tomcat-#{tcat_version}.tar.gz',
+        source_url => '#{TOMCAT6_RECENT_SOURCE}',
         catalina_base => '/opt/apache-tomcat/tomcat6',
       }->
       tomcat::config::server { 'tomcat6':
@@ -48,7 +38,7 @@ describe 'Two different instances of Tomcat 6 in the same manifest', :unless => 
       }->
       tomcat::war { 'tomcat6-sample.war':
         catalina_base => '/opt/apache-tomcat/tomcat6',
-        war_source    => 'https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war',
+        war_source    => '#{SAMPLE_WAR}',
         war_name      => 'tomcat6-sample.war',
       }->
       tomcat::service { 'tomcat6':
@@ -56,7 +46,7 @@ describe 'Two different instances of Tomcat 6 in the same manifest', :unless => 
       }
 
       tomcat::instance { 'tomcat6039':
-        source_url => 'http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.39/bin/apache-tomcat-6.0.39.tar.gz',
+        source_url => '#{TOMCAT_LEGACY_SOURCE}',
         catalina_base => '/opt/apache-tomcat/tomcat6039',
       }->
       tomcat::config::server { 'tomcat6039':
@@ -81,7 +71,7 @@ describe 'Two different instances of Tomcat 6 in the same manifest', :unless => 
       }->
       tomcat::war { 'tomcat6039-sample.war':
         catalina_base => '/opt/apache-tomcat/tomcat6039',
-        war_source    => 'https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war',
+        war_source    => '#{SAMPLE_WAR}',
         war_name      => 'tomcat6039-sample.war',
       }->
       tomcat::service { 'tomcat6039':
@@ -148,7 +138,7 @@ describe 'Two different instances of Tomcat 6 in the same manifest', :unless => 
       class{ 'tomcat':}
       tomcat::war { 'tomcat6039-sample.war':
         catalina_base => '/opt/apache-tomcat/tomcat6039',
-        war_source    => 'https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war',
+        war_source    => '#{SAMPLE_WAR}',
         war_name      => 'tomcat6039-sample.war',
         war_ensure    => 'absent',
       }->
@@ -158,7 +148,7 @@ describe 'Two different instances of Tomcat 6 in the same manifest', :unless => 
       }
       tomcat::war { 'tomcat6-sample.war':
         catalina_base => '/opt/apache-tomcat/tomcat6',
-        war_source    => 'https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war',
+        war_source    => '#{SAMPLE_WAR}',
         war_name      => 'tomcat6-sample.war',
         war_ensure    => 'false',
       }->
@@ -191,13 +181,13 @@ describe 'Two different instances of Tomcat 6 in the same manifest', :unless => 
       class{ 'tomcat':}
       tomcat::war { 'tomcat6-sample.war':
         catalina_base => '/opt/apache-tomcat/tomcat6',
-        war_source    => 'https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war',
+        war_source    => '#{SAMPLE_WAR}',
         war_name      => 'tomcat6-sample.war',
         war_ensure    => 'present',
       }
       tomcat::war { 'tomcat6039-sample.war':
         catalina_base => '/opt/apache-tomcat/tomcat6039',
-        war_source    => 'https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war',
+        war_source    => '#{SAMPLE_WAR}',
         war_name      => 'tomcat6039-sample.war',
         war_ensure    => 'true',
       }

--- a/spec/acceptance/acceptance_3_spec.rb
+++ b/spec/acceptance/acceptance_3_spec.rb
@@ -2,19 +2,9 @@ require 'spec_helper_acceptance'
 
 stop_test = true if UNSUPPORTED_PLATFORMS.any?{ |up| fact('osfamily') == up}
 
-tcat_version = String.new
-shell('curl -k http://tomcat.apache.org/download-70.cgi?Preferred=http%3A%2F%2Fwww.dsgnwrld.com%2Fam%2F', :acceptable_exit_codes => 0) do |r|
-  /apache-tomcat-(.{4,7}).tar.gz/.match(r.stdout).to_a.uniq.each do |m|
-    if m.length < 7
-      tcat_version = m
-      break
-    end
-  end
-end
-
 describe 'Tomcat Install source -defaults', :unless => stop_test do
 
-  shell('curl -k -o /tmp/sample.war https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war', :acceptable_exit_codes => 0)
+  shell("curl -k -o /tmp/sample.war '#{SAMPLE_WAR}'", :acceptable_exit_codes => 0)
 
   context 'Initial install Tomcat and verification' do
     it 'Should apply the manifest without error' do
@@ -22,7 +12,7 @@ describe 'Tomcat Install source -defaults', :unless => stop_test do
       class { 'tomcat':}
       class { 'java':}
       tomcat::instance { 'tomcat7':
-        source_url => 'http://www.dsgnwrld.com/am/tomcat/tomcat-7/v#{tcat_version}/bin/apache-tomcat-#{tcat_version}.tar.gz',
+        source_url    => '#{TOMCAT7_RECENT_SOURCE}',
         catalina_base => '/opt/apache-tomcat/tomcat7',
       }->
       tomcat::config::server { 'tomcat7':

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,6 +2,40 @@ require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 
 
+if ENV['BUILD_ID'] # We're in our CI system and use internal resources
+  ARTIFACT_HOST = ENV['TOMCAT_ARTIFACT_HOST'] || 'http://int-resources.corp.puppetlabs.net/QA_resources/tomcat'
+
+  TOMCAT6_RECENT_VERSION = ENV['TOMCAT6_RECENT_VERSION'] || 'latest6'
+  TOMCAT6_RECENT_SOURCE = "#{ARTIFACT_HOST}/apache-tomcat-#{TOMCAT6_RECENT_VERSION}.tar.gz"
+  TOMCAT7_RECENT_VERSION = ENV['TOMCAT7_RECENT_VERSION'] || 'latest7'
+  TOMCAT7_RECENT_SOURCE = "#{ARTIFACT_HOST}/apache-tomcat-#{TOMCAT7_RECENT_VERSION}.tar.gz"
+  TOMCAT8_RECENT_VERSION = ENV['TOMCAT8_RECENT_VERSION'] || 'latest8'
+  TOMCAT8_RECENT_SOURCE = "#{ARTIFACT_HOST}/apache-tomcat-#{TOMCAT8_RECENT_VERSION}.tar.gz"
+  TOMCAT_LEGACY_VERSION = ENV['TOMCAT_RECENT_VERSION'] || '6.0.39'
+  TOMCAT_LEGACY_SOURCE = "#{ARTIFACT_HOST}/apache-tomcat-#{TOMCAT_LEGACY_VERSION}.tar.gz"
+  SAMPLE_WAR = "#{ARTIFACT_HOST}/sample.war"
+
+else # We're outside the CI system and use default locations
+  require 'net/http'
+  latest_download_page = Net::HTTP.get(URI('http://tomcat.apache.org/download-60.cgi?Preferred=http%3A%2F%2Fmirror.symnds.com%2Fsoftware%2FApache%2F'))
+  latest6 = (match = latest_download_page.match(/apache-tomcat-(.{4,7}).tar.gz/) and match[1])
+  latest_download_page = Net::HTTP.get(URI('http://tomcat.apache.org/download-70.cgi?Preferred=http%3A%2F%2Fmirror.symnds.com%2Fsoftware%2FApache%2F'))
+  latest7 = (match = latest_download_page.match(/apache-tomcat-(.{4,7}).tar.gz/) and match[1])
+  latest_download_page = Net::HTTP.get(URI('http://tomcat.apache.org/download-80.cgi?Preferred=http%3A%2F%2Fmirror.symnds.com%2Fsoftware%2FApache%2F'))
+  latest8 = (match = latest_download_page.match(/apache-tomcat-(.{4,7}).tar.gz/) and match[1])
+
+  TOMCAT6_RECENT_VERSION = ENV['TOMCAT6_RECENT_VERSION'] || latest6
+  TOMCAT6_RECENT_SOURCE = "http://mirror.symnds.com/software/Apache/tomcat/tomcat-6/v#{TOMCAT6_RECENT_VERSION}/bin/apache-tomcat-#{TOMCAT6_RECENT_VERSION}.tar.gz"
+  TOMCAT7_RECENT_VERSION = ENV['TOMCAT7_RECENT_VERSION'] || latest7
+  TOMCAT7_RECENT_SOURCE = "http://www.dsgnwrld.com/am/tomcat/tomcat-7/v#{TOMCAT7_RECENT_VERSION}/bin/apache-tomcat-#{TOMCAT7_RECENT_VERSION}.tar.gz"
+  TOMCAT8_RECENT_VERSION = ENV['TOMCAT8_RECENT_VERSION'] || latest8
+  TOMCAT8_RECENT_SOURCE = "http://mirror.nexcess.net/apache/tomcat/tomcat-8/v#{TOMCAT8_RECENT_VERSION}/bin/apache-tomcat-#{TOMCAT8_RECENT_VERSION}.tar.gz"
+  TOMCAT_LEGACY_VERSION = ENV['TOMCAT_LEGACY_VERSION'] || '6.0.39'
+  TOMCAT_LEGACY_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-6/v#{TOMCAT_LEGACY_VERSION}/bin/apache-tomcat-#{TOMCAT_LEGACY_VERSION}.tar.gz"
+  SAMPLE_WAR = 'https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war'
+end
+
+
 unless ENV['RS_PROVISION'] == 'no'
   # This will install the latest available package on el and deb based
   # systems fail on windows and osx, and install via gem on other *nixes
@@ -15,6 +49,7 @@ unless ENV['RS_PROVISION'] == 'no'
 end
 
 UNSUPPORTED_PLATFORMS = ['windows','Solaris','Darwin']
+
 
 RSpec.configure do |c|
   # Project root


### PR DESCRIPTION
This refactors out download urls in the test manifests and parametrizes
them within the spec_helper_acceptance.rb to allow using internal
resources (default if ran in CI)
