### PR TITLE
Added manifest for managing Realm elements in server.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
         - [tomcat::config::server::engine](#tomcatconfigserverengine)
         - [tomcat::config::server::host](#tomcatconfigserverhost)
         - [tomcat::config::server::listener](#tomcatconfigserverlistener)
+        - [tomcat::config::server::realm](#tomcatconfigserverrealm)
         - [tomcat::config::server::service](#tomcatconfigserverservice)
         - [tomcat::config::server::valve](#tomcatconfigservervalve)
         - [tomcat::instance](#tomcatinstance)
@@ -135,7 +136,7 @@ tomcat::service { 'tomcat6':
 
 ###I want to deploy WAR files.
 
-The name of the WAR must end with '.war'. 
+The name of the WAR must end with '.war'.
 
 ```puppet
 tomcat::war { 'sample.war':
@@ -163,9 +164,9 @@ tomcat::config::server::connector { 'tomcat8-jsvc':
 }
 ```
 
-Then you would set `connector_ensure` to 'absent', and provide `notify` for the service. 
+Then you would set `connector_ensure` to 'absent', and provide `notify` for the service.
 
-```puppet 
+```puppet
 tomcat::config::server::connector { 'tomcat8-jsvc':
         catalina_base         => '/opt/apache-tomcat/tomcat8-jsvc',
         port                  => '80',
@@ -200,6 +201,7 @@ tomcat::config::server::connector { 'tomcat8-jsvc':
 * `tomcat::config::server::engine`: Configures [Engine](http://tomcat.apache.org/tomcat-8.0-doc/config/engine.html#Introduction) elements in $CATALINA_BASE/conf/server.xml.
 * `tomcat::config::server::host`: Configures [Host](http://tomcat.apache.org/tomcat-8.0-doc/config/host.html) elements in $CATALINA_BASE/conf/server.xml.
 * `tomcat::config::server::listener`: Configures [Listener](http://tomcat.apache.org/tomcat-8.0-doc/config/listeners.html) elements in $CATALINA_BASE/conf/server.xml.
+* `tomcat::config::server::realm`: Configures [Realm](http://tomcat.apache.org/tomcat-8.0-doc/config/realm.html) elements in $CATALINA_BASE/conf/server.xml.
 * `tomcat::config::server::service`: Configures a [Service](http://tomcat.apache.org/tomcat-8.0-doc/config/service.html) element nested in the Server element in $CATALINA_BASE/conf/server.xml.
 * `tomcat::config::server::valve`: Configures a [Valve](http://tomcat.apache.org/tomcat-8.0-doc/config/valve.html) element in $CATALINA_BASE/conf/server.xml.
 * `tomcat::instance`: Installs a Tomcat instance.
@@ -228,17 +230,25 @@ Sets the user to run Tomcat as.
 
 Sets the group to run Tomcat as.
 
-#####`$install_from_source` 
+#####`$install_from_source`
 
 Specifies whether or not to install from source. A Boolean that defaults to 'true'.
 
 #####`$purge_connectors`
 
-Specifies whether or not to purge existing Connector elements from server.xml. 
+Specifies whether or not to purge existing Connector elements from server.xml.
 
-For example, if you specify an HTTP connector element using ```tomcat::instance::connector``` and ```purge_connectors``` is set to ```true``` then existing HTTP connectors will be removed and only the HTTP connector you have specified will remain once the module has been applied.
+For example, if you specify an HTTP connector element using ```tomcat::config::server::connector``` and ```purge_connectors``` is set to ```true``` then existing HTTP connectors will be removed and only the HTTP connector you have specified will remain once the module has been applied.
 
 This is useful if you want to change the ports of existing connectors instead of adding additional connectors. Boolean that defaults to 'false'.
+
+#####`$purge_realms`
+
+Specifies whether or not to purge existing Realm elements from server.xml.
+
+For example, if you specify a Realm using ```tomcat::config::server::realm``` and ```purge_realms``` is set to ```true``` then existing Realm elements will be removed and only the Realm you have specified will remain once the module has been applied.
+
+Boolean that defaults to 'false'.
 
 #####`$manage_user`
 
@@ -262,15 +272,15 @@ Specifies the Java class name of the implementation to use, and maps to the [cla
 
 Specifies whether to set or remove the [className](http://tomcat.apache.org/tomcat-8.0-doc/config/server.html#Common_Attributes) XML attribute. Valid values are 'true', 'false', 'present', or 'absent'. Defaults to 'present'.
 
-#####`$address` 
+#####`$address`
 
 Sets the TCP/IP address on which the server waits for a shutdown command, and maps to the [address](http://tomcat.apache.org/tomcat-8.0-doc/config/server.html#Common_Attributes) XML attribute. This parameter is optional.
 
-#####`$address_ensure` 
+#####`$address_ensure`
 
 Specifies whether to set or remove the [address](http://tomcat.apache.org/tomcat-8.0-doc/config/server.html#Common_Attributes) XML attribute. Valid values are 'true', 'false', 'present', or 'absent'. Defaults to 'present'.
 
-#####`$port` 
+#####`$port`
 
 Sets the port to wait for shutdown commands on.
 
@@ -284,24 +294,24 @@ Specifies the command that must be sent to `$port`.
 
 Specifies the base directory for the Tomcat installation.
 
-#####`$connector_ensure` 
+#####`$connector_ensure`
 
 Specifies whether to add or remove ports that Tomcat will listen to for requests, and maps to the [Connector](http://tomcat.apache.org/tomcat-8.0-doc/connectors.html) XML element. Valid values are 'true', 'false', 'present', and 'absent'. Defaults to 'present'.
 
-#####`$port` 
+#####`$port`
 
 Sets the TCP port number on which the Connector will create a server socket and await incoming connections. Maps to the [port](http://tomcat.apache.org/tomcat-8.0-doc/config/http.html#Common_Attributes) XML attribute. Required unless `$connector_ensure` is set to 'false'.
 
-#####`$protocol` 
+#####`$protocol`
 
 Sets the protocol to handle incoming traffic. Maps to the [protocol](http://tomcat.apache.org/tomcat-8.0-doc/config/http.html#Common_Attributes) XML attribute. Defaults to '[name]' passed in the define.
 
-#####`$parent_service` 
+#####`$parent_service`
 
 Specifies the [Service](http://tomcat.apache.org/tomcat-8.0-doc/config/service.html#Introduction) element this Connector should be nested
 beneath. Defaults to 'Catalina'.
 
-#####`$additional_attributes` 
+#####`$additional_attributes`
 
 Specifies any additional attributes to add to the Connector. Should
 be a hash of the format 'attribute' => 'value'. This parameter is optional.
@@ -349,11 +359,11 @@ Specifies any attributes to remove from the Context. Should be a hash of the for
 
 Specifies the default host name for the host that will process requests directed to host names on this server, but which are not configured in this configuration file. Maps to the [defaultHost](http://tomcat.apache.org/tomcat-8.0-doc/config/engine.html#Common_Attributes) XML attribute for the Engine. This parameter is required.
 
-#####`$catalina_base` 
+#####`$catalina_base`
 
 Specifies the base directory for the Tomcat installation.
 
-#####`$background_processor_delay` 
+#####`$background_processor_delay`
 
 Determines the delay (in seconds) between the invocation of the backgroundProcess method on this engine and its child containers. Maps to the [backgroundProcessorDelay](http://tomcat.apache.org/tomcat-8.0-doc/config/engine.html#Common_Attributes) XML attribute. This parameter is optional.
 
@@ -365,54 +375,54 @@ Specifies whether to add or remove the [backgroundProcessorDelay](http://tomcat.
 
 Specifies the Java class name of the implementation to use, and maps to the [className](http://tomcat.apache.org/tomcat-8.0-doc/config/engine.html#Common_Attributes) XML attribute in the Tomcat config file. This parameter is optional.
 
-#####`$class_name_ensure` 
+#####`$class_name_ensure`
 
 Specifies whether to add or remove the [className](http://tomcat.apache.org/tomcat-8.0-doc/config/engine.html#Common_Attributes) XML attribute. Valid values are 'true', 'false', 'present', and 'absent'. Defaults to 'present'.
 
-#####`$engine_name` 
+#####`$engine_name`
 
 Specifies the logical name of the Engine, used in log and error messages. Maps to the [name](http://tomcat.apache.org/tomcat-8.0-doc/config/engine.html#Common_Attributes) XML attribute. Defaults to '[name]' passed in the define.
 
-#####`$jvm_route` 
+#####`$jvm_route`
 
 Specifies the identifier which must be used in load balancing scenarios to enable session affinity. Maps to the [jvmRoute](http://tomcat.apache.org/tomcat-8.0-doc/config/engine.html#Common_Attributes) XML attribute. This parameter is optional.
 
-#####`$jvm_route_ensure` 
+#####`$jvm_route_ensure`
 
 Specifies whether to add or remove the [jvmRoute](http://tomcat.apache.org/tomcat-8.0-doc/config/engine.html#Common_Attributes) XML attribute. Valid values are 'true', 'false', 'present', and 'absent'. Defaults to 'present'.
 
-#####`$parent_service` 
+#####`$parent_service`
 
 Specifies the Service element the Engine should be nested beneath. Defaults to 'Catalina'.
 
-#####`$start_stop_threads` 
+#####`$start_stop_threads`
 
 Sets the number of threads the Engine will use to start child Host elements in parallel. Maps to the [startStopThreads](http://tomcat.apache.org/tomcat-8.0-doc/config/engine.html#Common_Attributes) XML attribute. This parameter is optional.
 
-#####`$start_stop_threads_ensure` 
+#####`$start_stop_threads_ensure`
 
 Specifies whether to add or remove the [startStopThreads](http://tomcat.apache.org/tomcat-8.0-doc/config/engine.html#Common_Attributes) XML attribute. Valid values are 'true', 'false', 'present' and 'absent'. Defaults to 'present'.
 
 ####tomcat::config::server::host
 
-#####`$app_base` 
+#####`$app_base`
 
 Specifies the Application Base directory for the virtual host, and maps to the [appBase](http://tomcat.apache.org/tomcat-8.0-doc/config/host.html#Common_Attributes) XML attribute for the Host. This parameter is required
 unless [`$host_ensure`](#host_ensure) is set to 'false' or 'absent'.
 
-#####`$catalina_base` 
+#####`$catalina_base`
 
 Specifies the base directory for the Tomcat installation.
 
-#####`$host_ensure` 
+#####`$host_ensure`
 
 Specifies whether to add or remove the virtual host, or [Host](http://tomcat.apache.org/tomcat-8.0-doc/config/host.html#Introduction) element. Valid values are 'true', 'false', 'present', and 'absent'. Defaults to 'present'.
 
-#####`$host_name` 
+#####`$host_name`
 
 Specifies the the network name of the virtual host, as registered in your DNS server. Maps to the [name](http://tomcat.apache.org/tomcat-8.0-doc/config/host.html#Common_Attributes) XML attribute for the Host. Defaults to '[name]' passed in the define.
 
-#####`$parent_service` 
+#####`$parent_service`
 
 Specifies the Service element the Host should be nested beneath. Defaults to 'Catalina'.
 
@@ -421,7 +431,7 @@ Specifies the Service element the Host should be nested beneath. Defaults to 'Ca
 Specifies any additional attributes to add to the Host. Should
 be a hash of the format 'attribute' => 'value'. This parameter is optional
 
-#####`$attributes_to_remove` 
+#####`$attributes_to_remove`
 
 Specifies any attributes to remove from the Host. Should
 be an array of the format 'attribute' => 'value'. This parameter is optional.
@@ -460,21 +470,59 @@ Specifies any additional attributes to add to the Listener. Should be a hash of 
 
 Specifies any attributes to remove from the Listener. Should be a hash of the format 'attribute' => 'value'. This parameter is optional.
 
-####tomcat::config::server::service
+####tomcat::config::server::realm
 
-#####`$catalina_base` 
+#####`$catalina_base`
 
 Specifies the base directory for the Tomcat installation.
 
-#####`$class_name` 
+#####`$class_name`
+
+Specifies the Java class name of the Realm implementation to use. Maps to the [className](http://tomcat.apache.org/tomcat-8.0-doc/config/realm.html#Common_Attributes) XML attribute. Defaults to '[name]' passed in the define.
+
+#####`$realm_ensure`
+
+Specifies whether to add or remove this Realm element in the configuration file. Valid values are 'true', 'false', 'present', and 'absent'. Defaults to 'present'.
+
+#####`$parent_service`
+
+Specifies the Service element this Realm element should be nested beneath. Defaults to 'Catalina'.
+
+#####`$parent_engine`
+
+Specifies the Engine element this Realm should be nested beneath. Needs to be the `name` attribute for the desired Engine element. Defaults to 'Catalina'.
+
+#####`$parent_host`
+
+Specifies the Host element this Realm should be nested beneath. Needs to be the `name` attribute for the desired Host element. This parameter is optional.
+
+#####`$parent_realm`
+
+Specifies the Realm element this Realm should be nested beneath. Needs to be the `className` attribute for the desired Realm element. This parameter is optional.
+
+#####`$additional_attributes`
+
+Specifies any additional attributes to add to the Realm element. Should be a hash of the format 'attribute' => 'value'. This parameter is optional.
+
+#####`$attributes_to_remove`
+
+Specifies attributes to remove from the Realm element. Should be an array of attribute names. This parameter is optional.
+
+####tomcat::config::server::service
+
+#####`$catalina_base`
+
+Specifies the base directory for the Tomcat installation.
+
+#####`$class_name`
 
 Specifies the Java class name of the implementation to use, and maps to the [className](http://tomcat.apache.org/tomcat-8.0-doc/config/service.html#Common_Attributes) XML attribute. This parameter is optional.
 
-#####`$class_name_ensure` 
+#####`$class_name_ensure`
 
 Specifies whether to set or remove the [className](http://tomcat.apache.org/tomcat-8.0-doc/config/service.html#Common_Attributes) XML attribute. Valid values are 'true', 'false', 'present', or 'absent'. Defaults to 'present'.
 
-#####`$service_ensure` 
+#####`$service_ensure`
 
 Specifies whether to add or remove the [Service](http://tomcat.apache.org/tomcat-8.0-doc/config/service.html#Introduction) element. Valid values are 'true', 'false', 'present', or 'absent'. Defaults to 'present'.
 
@@ -488,15 +536,15 @@ Specifies the root of the Tomcat installation.
 
 Specifies the Java class name of the implementation to use. Maps to the [className](http://tomcat.apache.org/tomcat-8.0-doc/config/valve.html#Access_Logging/Attributes) XML attribute. Defaults to '[name]' passed in the define.
 
-#####`$parent_host` 
+#####`$parent_host`
 
 Specifies the virtual host ([Host](http://tomcat.apache.org/tomcat-8.0-doc/config/host.html#Common_Attributes) XML element) the Valve should be nested beneath. If not specified, the Valve will be nested beneath the Engine under `$parent_service`.
 
-#####`$parent_service` 
+#####`$parent_service`
 
 Specifies is the Service element this Valve should be nested beneath. Defaults to 'Catalina'.
 
-#####`$valve_ensure` 
+#####`$valve_ensure`
 
 Specifies whether to add or remove the component that will be inserted into the request processing pipeline for the associated Catalina container. Maps to the  [Valve](http://tomcat.apache.org/tomcat-8.0-doc/config/valve.html#Introduction) XML element. Valid values are 'true', 'false', 'present', or 'absent'. Defaults to 'present'.
 
@@ -510,41 +558,41 @@ Specifies any attributes to remove from the Valve. Should be a hash of the forma
 
 ####tomcat::instance
 
-#####`$catalina_home` 
+#####`$catalina_home`
 
 Specifies the root of the Tomcat installation. Only affects the instance installation if `$install_from_source` is true.
 
-#####`$catalina_base` 
+#####`$catalina_base`
 
 Specifies the base directory for the Tomcat installation. Only affects the instance installation if `$install_from_source` is true.
 
-#####`$install_from_source` 
+#####`$install_from_source`
 
 Specifies whether or not to install from source.
 
-#####`$source_url` 
+#####`$source_url`
 
 Specifies the source URL to install from. Required if `$install_from_source` is true.
 
-#####`$source_strip_first_dir` 
+#####`$source_strip_first_dir`
 
 Specifies whether or not to strip the first directory when unpacking the source tarball. A Boolean that defaults to 'true' when installing from source. Requires nanliu/staging > 0.4.0
 
-#####`$package_ensure` 
+#####`$package_ensure`
 
 Specifies what the ensure should be set to in the package resource when installing from a package.
 
-#####`$package_name` 
+#####`$package_name`
 
 Specifies the the name of the package you want to install. Required if `$install_from_source` is false.
 
 ####tomcat::service
 
-#####`$catalina_home` 
+#####`$catalina_home`
 
 Specifies the root of the Tomcat installation.
 
-#####`$catalina_base` 
+#####`$catalina_base`
 
 Specifies the base directory for the Tomcat installation.
 
@@ -557,7 +605,7 @@ Specifies whether or not to use Jsvc for service management. A Boolean that defa
 
 Specifies the path Java is installed under. Only applies if `$use_jsvc = 'true'`
 
-#####`$service_ensure` 
+#####`$service_ensure`
 
 Determines whether the Tomcat service is on or off. Valid values are 'running', 'stopped', 'true', and 'false'. (To determine whether the service is present/absent, see [tomcat::config::server::service](#tomcatconfigserverservice).)
 
@@ -568,25 +616,25 @@ tomcat module does not supply an init script, so setting `$use_init` to true wil
 If both `$use_jsvc` and `$use_init` are false, `$CATALINA_BASE/bin/catalina.sh start` and `$CATALINA_BASE/bin/catalina.sh stop` are used
 for service management.
 
-#####`$service_name` 
+#####`$service_name`
 
 Specifies the name to use for the service when `$use_init` is 'true'.
 
-#####`$start_command` 
+#####`$start_command`
 
 Sets the start command to use for the service.
 
-#####`$stop_command` 
+#####`$stop_command`
 
 Sets the stop command to use for the service.
 
 ####tomcat::setenv::entry
 
-#####`$value` 
+#####`$value`
 
-Specifies the value of the parameter you're setting.  If array is passed, values are separated with a single space. 
+Specifies the value of the parameter you're setting.  If array is passed, values are separated with a single space.
 
-#####`$ensure` 
+#####`$ensure`
 
 Determines whether the fragment should be present or absent.
 
@@ -594,7 +642,7 @@ Determines whether the fragment should be present or absent.
 
 Path to the configuration file to edit. Defaults to '$::tomcat::catalina_home/bin/setenv.sh'.
 
-#####`$base_path` 
+#####`$base_path`
 
 Sets the path to create the setenv.sh script under. Should be either '$catalina_base/bin' or '$catalina_home/bin'. **Deprecated** This parameter is being deperecated, please use `$config_file`.
 
@@ -608,7 +656,7 @@ Specifies the character with which to quote the value. This parameter is optiona
 
 ####tomcat::war
 
-#####`$catalina_base` 
+#####`$catalina_base`
 
 Specifies the base directory for the Tomcat installation.
 
@@ -620,7 +668,7 @@ Specifies the path relative to `$catalina_base` to deploy the WAR to. Defaults t
 
 Specifies the path to deploy the WAR to. This parameter is optional. You may only specify either `$app_base` or `$deployment_path`, but not both..
 
-#####`$war_ensure` 
+#####`$war_ensure`
 
 Specifies whether to add or remove the WAR. Valid values are 'present', 'absent', 'true', and 'false'. Defaults to 'present'.
 
@@ -632,7 +680,7 @@ Specifies the name of the WAR. Must end in '.war'. Defaults to '[name]' passed i
 
 Specifies whether to purge the exploded WAR directory.  Boolean defaulting to true. This parameter is only applicable when `$war_ensure` is 'absent' or 'false'. Setting this parameter to false will not prevent Tomcat from removing the exploded WAR directory if Tomcat is running and autoDeploy is set to true.
 
-#####`$war_source` 
+#####`$war_source`
 
 Specifies the source to deploy the WAR from. Currently supports http(s)://, puppet://, and ftp:// paths. `$war_source` must be specified unless `$war_ensure` is set to 'false' or 'absent'.
 

--- a/examples/instance_with_realm.pp
+++ b/examples/instance_with_realm.pp
@@ -1,0 +1,18 @@
+# This code fragment downloads Tomcat 8.0.15, configures an instance, and adds a JNDIRealm nested under a LockOutRealm.
+class { 'tomcat': }
+class { 'java': }
+
+tomcat::instance { 'tomcat8':
+  source_url    => 'http://mirror.reverse.net/pub/apache/tomcat/tomcat-8/v8.0.15/bin/apache-tomcat-8.0.15.tar.gz',
+  purge_realms => true,
+}->
+
+tomcat::config::server::realm { 'org.apache.catalina.realm.LockOutRealm':
+  realm_ensure => 'present',
+} ->
+
+tomcat::config::server::realm { 'org.apache.catalina.realm.JNDIRealm':
+  realm_ensure => 'present',
+  parent_realm => 'org.apache.catalina.realm.LockOutRealm',
+  additional_attributes => { 'connectionURL' => 'ldap://localhost' },
+}

--- a/manifests/config/server/realm.pp
+++ b/manifests/config/server/realm.pp
@@ -1,0 +1,97 @@
+# Definition: tomcat::config::server::realm
+#
+# Configure Realm elements in $CATALINA_BASE/conf/server.xml
+#
+# Parameters:
+# - $catalina_base is the base directory for the Tomcat installation.
+# - $class_name is the Java class name of the Realm implementation to use.
+# - $realm_ensure specifies whether you are adding or removing a
+#   Realm element. Valid values are 'true', 'false', 'present', and
+#   'absent'. Defaults to 'present'.
+# - $parent_service is the `name` attribute for the Service element this Realm
+#   should be nested beneath. Defaults to 'Catalina'.
+# - $parent_engine is the `name` attribute for the Engine element this Realm
+#   should be nested beneath. Defaults to 'Catalina'.
+# - $parent_host is the `name` attribute for the Host element this Realm
+#   should be nested beneath.
+# - $parent_realm is the `name` attribute for the Realm element this Realm
+#   should be nested beneath.
+# - An optional hash of $additional_attributes to add to the Realm. Should
+#   be of the format 'attribute' => 'value'.
+# - An optional array of $attributes_to_remove from the Realm.
+define tomcat::config::server::realm (
+  $catalina_base         = $::tomcat::catalina_home,
+  $class_name            = $name,
+  $realm_ensure          = 'present',
+  $parent_service        = 'Catalina',
+  $parent_engine         = 'Catalina',
+  $parent_host           = undef,
+  $parent_realm          = undef,
+  $additional_attributes = {},
+  $attributes_to_remove  = [],
+  $purge_realms          = $::tomcat::purge_realms,
+) {
+
+  if versioncmp($::augeasversion, '1.0.0') < 0 {
+    fail('Server configurations require Augeas >= 1.0.0')
+  }
+  validate_re($realm_ensure, '^(present|absent|true|false)$')
+  validate_hash($additional_attributes)
+  validate_array($attributes_to_remove)
+  validate_bool($purge_realms)
+
+  if $purge_realms and ($realm_ensure =~ /^(absent|false)$/) {
+    fail('$realm_ensure must be set to \'true\' or \'present\' to use $purge_realms')
+  }
+
+  if $purge_realms {
+    $_purge_realms = "rm Server//Realm"
+  } else {
+    $_purge_realms = undef
+  }
+
+  $engine_path = "Server/Service[#attribute/name='${parent_service}']/Engine[#attribute/name='${parent_engine}']"
+
+  # The Realm may be nested under a Host element.
+  if $parent_host {
+    $host_path = "${engine_path}/Host[#attribute/name='${parent_host}']"
+  } else {
+    $host_path = "${engine_path}"
+  }
+
+  # The Realm could also be nested under another Realm element if the parent realm is a CombinedRealm.
+  if $parent_realm {
+    $path = "${host_path}/Realm[#attribute/className='${parent_realm}']/Realm"
+  }
+  else {
+    $path = "${host_path}/Realm"
+  }
+
+  if $realm_ensure =~ /^(absent|false)$/ {
+    $changes = "rm ${path}[#attribute/className='${class_name}']"
+  }
+  else {
+
+    $_class_name = "set ${path}/#attribute/className ${class_name}"
+
+    if ! empty($additional_attributes) {
+      $_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${path}[#attribute/className='${class_name}']/#attribute/"), "'")
+    } else {
+      $_additional_attributes = undef
+    }
+    if ! empty(any2array($attributes_to_remove)) {
+      $_attributes_to_remove = prefix(any2array($attributes_to_remove), "rm ${path}[#attribute/className='${class_name}']/#attribute/")
+    } else {
+      $_attributes_to_remove = undef
+    }
+
+    $changes = delete_undef_values(flatten([ $_purge_realms, $_class_name, $_additional_attributes, $_attributes_to_remove ]))
+  }
+
+  augeas { "${catalina_base}-${parent_service}-${parent_engine}-${parent_host}-${parent_realm}-realm-${class_name}":
+    lens    => 'Xml.lns',
+    incl    => "${catalina_base}/conf/server.xml",
+    changes => $changes,
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,12 @@
 # [*manage_user*]
 #   Boolean specifying whether or not to manage the user. Defaults to true.
 #
+# [*purge_connectors*]
+#   Boolean specifying whether to purge all Connector elements from server.xml. Defaults to false.
+#
+# [*purge_realms*]
+#   Boolean specifying whether to purge all Realm elements from server.xml. Defaults to false.
+#
 # [*manage_group*]
 #   Boolean specifying whether or not to manage the group. Defaults to true.
 #
@@ -25,11 +31,13 @@ class tomcat (
   $group               = $::tomcat::params::group,
   $install_from_source = true,
   $purge_connectors    = false,
+  $purge_realms        = false,
   $manage_user         = true,
   $manage_group        = true,
 ) inherits ::tomcat::params {
   validate_bool($install_from_source)
   validate_bool($purge_connectors)
+  validate_bool($purge_realms)
   validate_bool($manage_user)
   validate_bool($manage_group)
 

--- a/spec/defines/config/server/realm_spec.rb
+++ b/spec/defines/config/server/realm_spec.rb
@@ -1,0 +1,320 @@
+require 'spec_helper'
+
+describe 'tomcat::config::server::realm', :type => :define do
+  let :pre_condition do
+    'class { "tomcat": }'
+  end
+  let :facts do
+    {
+      :osfamily => 'Debian',
+      :augeasversion => '1.0.0'
+    }
+  end
+  let :title do
+    'org.apache.catalina.realm.JNDIRealm'
+  end
+  context 'Add Realm' do
+    let :params do
+      {
+         :class_name            => 'org.apache.catalina.realm.JNDIRealm',
+         :catalina_base         => '/opt/apache-tomcat/test',
+         :realm_ensure          => 'present',
+         :additional_attributes => {
+          'connectionURL' => 'ldap://localhost',
+          'roleName'      => 'cn',
+          'roleSearch'    => 'member={0}',
+          'spaces'        => 'foo bar',
+         },
+         :attributes_to_remove  => [
+           'foo',
+           'bar',
+           'baz',
+         ],
+      }
+    end
+    it { is_expected.to contain_augeas('/opt/apache-tomcat/test-Catalina-Catalina---realm-org.apache.catalina.realm.JNDIRealm').with(
+      'lens'    => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
+      'changes' => [
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm/#attribute/className org.apache.catalina.realm.JNDIRealm",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/connectionURL 'ldap://localhost'",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/roleName 'cn'",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/roleSearch 'member={0}'",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/spaces 'foo bar'",
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/foo",
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/bar",
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/baz",
+      ]
+    )
+    }
+  end
+  context 'Purge Realms' do
+    let :params do
+      {
+        :purge_realms => true,
+        :class_name => 'org.apache.catalina.realm.JNDIRealm',
+        :catalina_base => '/opt/apache-tomcat/test',
+        :realm_ensure => 'true',
+        :additional_attributes => {
+          'connectionURL' => 'ldap://localhost',
+          'roleName'      => 'cn',
+        },
+        :attributes_to_remove  => [
+          'foo',
+          'bar',
+        ],
+      }
+    end
+    it { is_expected.to contain_augeas('/opt/apache-tomcat/test-Catalina-Catalina---realm-org.apache.catalina.realm.JNDIRealm').with(
+      'lens' => 'Xml.lns',
+      'incl' => '/opt/apache-tomcat/test/conf/server.xml',
+      'changes' => [
+        "rm Server//Realm",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm/#attribute/className org.apache.catalina.realm.JNDIRealm",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/connectionURL 'ldap://localhost'",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/roleName 'cn'",
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/foo",
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/bar",
+      ]
+    )
+    }
+  end
+  context 'No class_name' do
+    let :title do
+      'org.apache.catalina.realm.JNDIRealm'
+    end
+    let :params do
+      {
+        :catalina_base => '/opt/apache-tomcat/test',
+        :realm_ensure => 'present',
+      }
+    end
+    it { is_expected.to contain_augeas('/opt/apache-tomcat/test-Catalina-Catalina---realm-org.apache.catalina.realm.JNDIRealm').with(
+      'lens' => 'Xml.lns',
+      'incl' => '/opt/apache-tomcat/test/conf/server.xml',
+      'changes' => [
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm/#attribute/className org.apache.catalina.realm.JNDIRealm",
+      ]
+    )
+    }
+  end
+  context '$realm_ensure absent' do
+    let :title do
+      'org.apache.catalina.realm.LockOutRealm'
+    end
+    let :params do
+      {
+        :catalina_base => '/opt/apache-tomcat/test',
+        :realm_ensure => 'absent',
+      }
+    end
+    it { is_expected.to contain_augeas('/opt/apache-tomcat/test-Catalina-Catalina---realm-org.apache.catalina.realm.LockOutRealm').with(
+      'lens' => 'Xml.lns',
+      'incl' => '/opt/apache-tomcat/test/conf/server.xml',
+      'changes' => [
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']",
+      ]
+    )
+    }
+  end
+  context '$realm_ensure false' do
+    let :title do
+      'org.apache.catalina.realm.LockOutRealm'
+    end
+    let :params do
+      {
+        :catalina_base => '/opt/apache-tomcat/test',
+        :realm_ensure => 'false',
+      }
+    end
+    it { is_expected.to contain_augeas('/opt/apache-tomcat/test-Catalina-Catalina---realm-org.apache.catalina.realm.LockOutRealm').with(
+      'lens' => 'Xml.lns',
+      'incl' => '/opt/apache-tomcat/test/conf/server.xml',
+      'changes' => [
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']",
+      ]
+    )
+    }
+  end
+  context 'Add Realm with $parent_service and $parent_engine' do
+    let :title do
+      'org.apache.catalina.realm.JNDIRealm'
+    end
+    let :params do
+      {
+        :catalina_base => '/opt/apache-tomcat/test',
+        :parent_service => 'NewService',
+        :parent_engine => 'AnotherEngine',
+        :realm_ensure => 'present',
+      }
+    end
+    it { is_expected.to contain_augeas('/opt/apache-tomcat/test-NewService-AnotherEngine---realm-org.apache.catalina.realm.JNDIRealm').with(
+      'lens' => 'Xml.lns',
+       'incl' => '/opt/apache-tomcat/test/conf/server.xml',
+       'changes' => [
+         "set Server/Service[#attribute/name='NewService']/Engine[#attribute/name='AnotherEngine']/Realm/#attribute/className org.apache.catalina.realm.JNDIRealm",
+       ]
+    )
+    }
+  end
+  context 'Add Realm with $parent_host' do
+    let :title do
+      'org.apache.catalina.realm.JNDIRealm'
+    end
+    let :params do
+      {
+        :catalina_base => '/opt/apache-tomcat/test',
+        :parent_host => 'localhost',
+        :realm_ensure => 'present',
+      }
+    end
+    it { is_expected.to contain_augeas('/opt/apache-tomcat/test-Catalina-Catalina-localhost--realm-org.apache.catalina.realm.JNDIRealm').with(
+      'lens' => 'Xml.lns',
+       'incl' => '/opt/apache-tomcat/test/conf/server.xml',
+       'changes' => [
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Host[#attribute/name='localhost']/Realm/#attribute/className org.apache.catalina.realm.JNDIRealm",
+       ]
+    )
+    }
+  end
+  context 'Add Realm with $parent_host and $parent_realm' do
+    let :title do
+      'org.apache.catalina.realm.JNDIRealm'
+    end
+    let :params do
+      {
+        :catalina_base => '/opt/apache-tomcat/test',
+        :parent_host => 'localhost',
+        :parent_realm => 'org.apache.catalina.realm.LockOutRealm',
+        :realm_ensure => 'present',
+      }
+    end
+    it { is_expected.to contain_augeas('/opt/apache-tomcat/test-Catalina-Catalina-localhost-org.apache.catalina.realm.LockOutRealm-realm-org.apache.catalina.realm.JNDIRealm').with(
+      'lens' => 'Xml.lns',
+       'incl' => '/opt/apache-tomcat/test/conf/server.xml',
+       'changes' => [
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Host[#attribute/name='localhost']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm/#attribute/className org.apache.catalina.realm.JNDIRealm",
+       ]
+    )
+    }
+  end
+  context 'Add Realm with $parent_realm only' do
+    let :title do
+      'org.apache.catalina.realm.JNDIRealm'
+    end
+    let :params do
+      {
+        :catalina_base => '/opt/apache-tomcat/test',
+        :parent_realm => 'org.apache.catalina.realm.LockOutRealm',
+        :realm_ensure => 'present',
+         :additional_attributes => {
+          'connectionURL' => 'ldap://localhost',
+          'roleName'      => 'cn',
+          'roleSearch'    => 'member={0}',
+          'spaces'        => 'foo bar',
+         },
+      }
+    end
+    it { is_expected.to contain_augeas('/opt/apache-tomcat/test-Catalina-Catalina--org.apache.catalina.realm.LockOutRealm-realm-org.apache.catalina.realm.JNDIRealm').with(
+      'lens' => 'Xml.lns',
+       'incl' => '/opt/apache-tomcat/test/conf/server.xml',
+       'changes' => [
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm/#attribute/className org.apache.catalina.realm.JNDIRealm",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/connectionURL 'ldap://localhost'",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/roleName 'cn'",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/roleSearch 'member={0}'",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/spaces 'foo bar'",
+       ]
+    )
+    }
+  end
+  context 'Failing Tests' do
+    context 'Bad realm_ensure' do
+      let :params do
+        {
+          :realm_ensure => 'foo',
+        }
+      end
+      it do
+        expect {
+          is_expected.to compile
+        }. to raise_error(Puppet::Error, /does not match/)
+      end
+    end
+    context 'Bad additional_attributes' do
+      let :params do
+        {
+          :additional_attributes => 'foo',
+        }
+      end
+      it do
+        expect {
+          is_expected.to compile
+        }. to raise_error(Puppet::Error, /is not a Hash/)
+      end
+    end
+    context 'Bad attributes_to_remove' do
+      let :params do
+        {
+          :attributes_to_remove => 'foo',
+        }
+      end
+      it do
+        expect {
+          is_expected.to compile
+        }. to raise_error(Puppet::Error, /is not an Array/)
+      end
+    end
+    context 'Bad purge_realms' do
+      let :params do
+        {
+          :purge_realms => 'true',
+        }
+      end
+      it do
+        expect {
+          is_expected.to compile
+        }. to raise_error(Puppet::Error, /is not a boolean/)
+      end
+    end
+    context 'Purge realms with $realm_ensure => false' do
+      let :params do
+        {
+          :realm_ensure => 'false',
+          :purge_realms => true,
+        }
+      end
+      it do
+        expect {
+          is_expected.to compile
+        }. to raise_error(Puppet::Error, /\$realm_ensure must be set to 'true' or 'present' to use \$purge_realms/)
+      end
+    end
+    context 'Purge realms with $realm_ensure => absent' do
+      let :params do
+        {
+          :realm_ensure => 'absent',
+          :purge_realms => true,
+        }
+      end
+      it do
+        expect {
+          is_expected.to compile
+        }. to raise_error(Puppet::Error, /\$realm_ensure must be set to 'true' or 'present' to use \$purge_realms/)
+      end
+    end
+    context 'old augeas' do
+      let :facts do
+        {
+          :osfamily      => 'Debian',
+          :augeasversion => '0.10.0'
+        }
+      end
+      it do
+        expect {
+          is_expected.to compile
+        }.to raise_error(Puppet::Error, /configurations require Augeas >= 1.0.0/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Initial revision of manifest and spec tests for managing Realm elements in server.xml. Updated README and added an example manifest for Tomcat 8 showing configuration of a JNDIRealm. Corrected a few other minor documentation issues.