### PR TITLE
Add source support for Solaris

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,10 +42,14 @@ class tomcat (
   validate_bool($manage_group)
 
   case $::osfamily {
-    'windows','Solaris','Darwin': {
+    'windows','Darwin': {
       fail("Unsupported osfamily: ${::osfamily}")
     }
     default: { }
+  }
+
+  if $::osfamily == 'Solaris' and $install_from_source == false {
+      fail("Solaris only supports source install, package install not tested")
   }
 
   if $install_from_source {

--- a/manifests/instance/source.pp
+++ b/manifests/instance/source.pp
@@ -38,7 +38,7 @@ define tomcat::instance::source (
     source  => "${::staging::path}/tomcat/${filename}",
     target  => $catalina_base,
     require => Staging::File[$filename],
-    unless  => "test \"\$(ls -A ${catalina_base})\"",
+    onlyif  => "test -z \"`ls -A ${catalina_base}`\"",
     user    => $::tomcat::user,
     group   => $::tomcat::group,
     strip   => $_strip,


### PR DESCRIPTION
- tested with Red Hat Tomcat on Solaris 10 Spark
  (jboss-ews-application-servers-2.1.0-sun10.sparc64.zip)
- Ticket MODULES-1879 at https://tickets.puppetlabs.com/browse/MODULES-1879
- I had to change the directory empty comparison due $(command) method not
  working on Solaris. The `command` notation works on both Linux and Solaris.