### PR TITLE
enable install options in package resource

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -17,6 +17,8 @@
 #   to in the package resource.
 # - $package_name is the name of the package you want to install. Required if
 #   $install_from_source is false.
+# - $install_options when installing the package, what extra options should be
+#   set in the package resource.
 define tomcat::instance (
   $catalina_home          = undef,
   $catalina_base          = undef,
@@ -25,6 +27,7 @@ define tomcat::instance (
   $source_strip_first_dir = undef,
   $package_ensure         = undef,
   $package_name           = undef,
+  $install_options        = undef,
 ) {
 
   if $install_from_source {
@@ -74,7 +77,8 @@ define tomcat::instance (
     }
   } else {
     tomcat::instance::package { $package_name:
-      package_ensure => $package_ensure,
+      package_ensure  => $package_ensure,
+      install_options => $install_options,
     }
   }
 


### PR DESCRIPTION
I recently had a case where I wanted to pass additional install options to yum on a centos install of tomcat 7.  The particular options were to disable a project repo which we had provisioned which also contained a tomcat package but at version 6.  Without the ability to pass '--disablerepo=myrepo' to the effective yum command, I could not get the module install to install the EPEL tomcat version, in favour of our own package.

To facilitate passing extra install options I have added this attribute to the package resource.