### PR TITLE
enable install options in package resource

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -17,6 +17,7 @@
 #   to in the package resource.
 # - $package_name is the name of the package you want to install. Required if
 #   $install_from_source is false.
+# - $install_options to pass extra options to the package resource.
 define tomcat::instance (
   $catalina_home          = undef,
   $catalina_base          = undef,
@@ -25,6 +26,7 @@ define tomcat::instance (
   $source_strip_first_dir = undef,
   $package_ensure         = undef,
   $package_name           = undef,
+  $install_options        = undef,
 ) {
 
   if $install_from_source {
@@ -74,7 +76,8 @@ define tomcat::instance (
     }
   } else {
     tomcat::instance::package { $package_name:
-      package_ensure => $package_ensure,
+      package_ensure   => $package_ensure,
+      install_options  => $install_options, 
     }
   }
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -76,8 +76,8 @@ define tomcat::instance (
     }
   } else {
     tomcat::instance::package { $package_name:
-      package_ensure   => $package_ensure,
-      install_options  => $install_options, 
+      package_ensure  => $package_ensure,
+      install_options => $install_options,
     }
   }
 

--- a/manifests/instance/package.pp
+++ b/manifests/instance/package.pp
@@ -5,6 +5,7 @@
 # Parameters:
 # - $package_ensure is the ensure passed to the package resource.
 # - The $package_name you want to install.
+# - $install_options to pass extra options to the package resource.
 define tomcat::instance::package (
   $package_ensure  = 'installed',
   $package_name    = undef,

--- a/manifests/instance/package.pp
+++ b/manifests/instance/package.pp
@@ -6,8 +6,9 @@
 # - $package_ensure is the ensure passed to the package resource.
 # - The $package_name you want to install.
 define tomcat::instance::package (
-  $package_ensure = 'installed',
-  $package_name = undef,
+  $package_ensure  = 'installed',
+  $package_name    = undef,
+  $install_options = undef,
 ) {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
@@ -20,7 +21,8 @@ define tomcat::instance::package (
   }
 
   package { $_package_name:
-    ensure => $package_ensure
+    ensure          => $package_ensure,
+    install_options => $install_options,
   }
 
 }


### PR DESCRIPTION
I recently had a case where I wanted to pass additional install options to yum on a centos install of tomcat 7.  The particular options were to disable a project repo which we had provisioned which also contained a tomcat package but at version 6.  Without the ability to pass '--disablerepo=myrepo' to the effective yum command, I could not get the module install to install the EPEL tomcat version, in favour of our own package.

To facilitate passing extra install options I have added this attribute to the package resource.