### PR TITLE
Wrap username attribute in quotes.

### DIFF
--- a/manifests/config/server/tomcat_users.pp
+++ b/manifests/config/server/tomcat_users.pp
@@ -42,7 +42,7 @@ define tomcat::config::server::tomcat_users (
   if $element == 'role' and ( $password or ! empty($roles) ) {
     warning('$password and $roles are useless when $element is set to \'role\'')
   }
-  
+
   if $element == 'user' {
     $element_identifier = 'username'
   } else {
@@ -54,13 +54,13 @@ define tomcat::config::server::tomcat_users (
   } else {
     $_element_name = $name
   }
-  
+
   if $file {
     $_file = $file
   } else {
     $_file = "${catalina_base}/conf/tomcat-users.xml"
   }
-  
+
   if $manage_file {
     ensure_resource('file', $_file, {
       ensure  => file,
@@ -78,7 +78,7 @@ define tomcat::config::server::tomcat_users (
   if $ensure =~ /^(absent|false)$/ {
     $remove_entry = "rm ${path}"
   } else {
-    $add_entry = "set ${path}/#attribute/${element_identifier} ${_element_name}"
+    $add_entry = "set ${path}/#attribute/${element_identifier} '${_element_name}'"
     if $element == 'user' {
       $add_password = "set ${path}/#attribute/password '${password}'"
       $add_roles = join(["set ${path}/#attribute/roles '",join($roles, ','),"'"])

--- a/spec/defines/config/server/tomcat_users_spec.rb
+++ b/spec/defines/config/server/tomcat_users_spec.rb
@@ -35,7 +35,7 @@ describe 'tomcat::config::server::tomcat_users', :type => :define do
       'lens'    => 'Xml.lns',
       'incl'    => '/opt/apache-tomcat/test/conf/tomcat-users.xml',
       'changes' => [
-        'set tomcat-users/user[#attribute/username=\'foo\']/#attribute/username foo',
+        'set tomcat-users/user[#attribute/username=\'foo\']/#attribute/username \'foo\'',
         'set tomcat-users/user[#attribute/username=\'foo\']/#attribute/password \'bar\'',
         'set tomcat-users/user[#attribute/username=\'foo\']/#attribute/roles \'foo_role,bar_role\'',
       ],
@@ -68,7 +68,7 @@ describe 'tomcat::config::server::tomcat_users', :type => :define do
       'lens'    => 'Xml.lns',
       'incl'    => '/opt/apache-tomcat/test/conf/tomcat-users.xml',
       'changes' => [
-        'set tomcat-users/user[#attribute/username=\'foo\']/#attribute/username foo',
+        'set tomcat-users/user[#attribute/username=\'foo\']/#attribute/username \'foo\'',
         'set tomcat-users/user[#attribute/username=\'foo\']/#attribute/password \'very-secret-password\'',
         'set tomcat-users/user[#attribute/username=\'foo\']/#attribute/roles \'foobar\'',
       ],
@@ -94,7 +94,7 @@ describe 'tomcat::config::server::tomcat_users', :type => :define do
       'lens'    => 'Xml.lns',
       'incl'    => '/opt/apache-tomcat/test/conf/users.xml',
       'changes' => [
-        'set tomcat-users/user[#attribute/username=\'foo\']/#attribute/username foo',
+        'set tomcat-users/user[#attribute/username=\'foo\']/#attribute/username \'foo\'',
         'set tomcat-users/user[#attribute/username=\'foo\']/#attribute/password \'bar\'',
         'set tomcat-users/user[#attribute/username=\'foo\']/#attribute/roles \'role\'',
       ],
@@ -147,7 +147,7 @@ describe 'tomcat::config::server::tomcat_users', :type => :define do
       'lens'    => 'Xml.lns',
       'incl'    => '/opt/apache-tomcat/test/conf/tomcat-users.xml',
       'changes' => [
-        'set tomcat-users/role[#attribute/rolename=\'foobar\']/#attribute/rolename foobar',
+        'set tomcat-users/role[#attribute/rolename=\'foobar\']/#attribute/rolename \'foobar\'',
       ],
       'require' => 'File[/opt/apache-tomcat/test/conf/tomcat-users.xml]',
     )
@@ -168,7 +168,7 @@ describe 'tomcat::config::server::tomcat_users', :type => :define do
       'lens'    => 'Xml.lns',
       'incl'    => '/opt/apache-tomcat/test/conf/tomcat-users.xml',
       'changes' => [
-        'set tomcat-users/role[#attribute/rolename=\'noname\']/#attribute/rolename noname',
+        'set tomcat-users/role[#attribute/rolename=\'noname\']/#attribute/rolename \'noname\'',
       ],
       'require' => 'File[/opt/apache-tomcat/test/conf/tomcat-users.xml]',
     )


### PR DESCRIPTION
Wrap username attribute in quotes to allow for username values that contain whitespaces. When using CLIENT_AUTH (2-way SSL) authentication, the client name will contain the certificate subject as the value (like: 'C=CA, ST=Alberta, L=Calgary, O=Shaw, OU=BSS, CN=my_client').

This is a fix for [JIRA Ticket MODULES-2284](https://tickets.puppetlabs.com/browse/MODULES-2284).