### PR TITLE
[#puppethack] Validate that catalina_base does not to end with /

### DIFF
--- a/manifests/config/server/connector.pp
+++ b/manifests/config/server/connector.pp
@@ -33,7 +33,8 @@ define tomcat::config::server::connector (
   validate_re($connector_ensure, '^(present|absent|true|false)$')
   validate_hash($additional_attributes)
   validate_bool($purge_connectors)
-
+  validate_re($catalina_base, '^.*[^/]$', '$catalina_base must not end in a /!')
+  
   if $protocol {
     $_protocol = $protocol
   } else {


### PR DESCRIPTION
Unfortunately Augeas does not work if path contains double slash, it simply
does not find the file and fails silently to update it.

I've added the validate_re to save others some time.