### PR TITLE
(MODULES-2471) Specify port when purging connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,9 @@ Determines whether to create the specified user, if it doesn't exist. Uses Puppe
 
 #####`purge_connectors`
 
-Specifies whether to purge any unmanaged Connector elements from the configuration file. Valid options: 'true' and 'false'. Default: 'false'.
+Specifies whether to purge any unmanaged Connector elements that match
+defined protocol but have a different port
+from the configuration file. Valid options: 'true' and 'false'. Default: 'false'.
 
 #####`purge_realms`
 

--- a/manifests/config/server/connector.pp
+++ b/manifests/config/server/connector.pp
@@ -34,7 +34,7 @@ define tomcat::config::server::connector (
   validate_hash($additional_attributes)
   validate_bool($purge_connectors)
   validate_re($catalina_base, '^.*[^/]$', '$catalina_base must not end in a /!')
-  
+
   if $protocol {
     $_protocol = $protocol
   } else {
@@ -44,7 +44,7 @@ define tomcat::config::server::connector (
   $path = "Server/Service[#attribute/name='${parent_service}']"
 
   if $purge_connectors {
-    $_purge_connectors = "rm Server//Connector[#attribute/protocol='${_protocol}']"
+    $_purge_connectors = "rm Server//Connector[#attribute/protocol='${_protocol}'][#attribute/port!='${port}']"
   } else {
     $_purge_connectors = undef
   }

--- a/spec/defines/config/server/connector_spec.rb
+++ b/spec/defines/config/server/connector_spec.rb
@@ -73,7 +73,7 @@ describe 'tomcat::config::server::connector', :type => :define do
       'lens'    => 'Xml.lns',
       'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
       'changes' => [
-        'rm Server//Connector[#attribute/protocol=\'AJP/1.3\']',
+        'rm Server//Connector[#attribute/protocol=\'AJP/1.3\'][#attribute/port!=\'8180\']',
         'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/port 8180',
         'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/protocol AJP/1.3',
         'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/redirectPort \'8543\'',


### PR DESCRIPTION
This commit change the behavior of 'purge_connectors' so that it will
purge ports of the same protocol that have a different port than
specified.

Prior to this commit, *all* connectors that matched the protocol were
purged, including the desired one.  This resulted in a purge/create
every Puppet run.

Refer to https://tickets.puppetlabs.com/browse/MODULES-2471

Update spec for purge_connectors

Should purge connectors that match the protocol and have a different
port

Provide more clarity for purge_connectors in readme