### PR TITLE
(MAINT) enable install options in package resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,10 @@ Determines whether the specified package should be installed. Only valid if `ins
 
 *Required if `install_from_source` is set to 'false'.* Specifies the package to install. Valid options: a string containing a valid package name.
 
+#####`package_options`
+
+*Unused if `install_from_source` is set to 'true'.* Specify additional options to use on the generated package resource. See the documentation of the [`package` resource type](https://docs.puppetlabs.com/references/latest/type.html#package-attribute-install_options) for possible values.
+
 #####`source_strip_first_dir`
 
 Specifies whether to strip the topmost directory of the tarball when unpacking it. Only valid if `install_from_source` is set to 'true'. Valid options: 'true' and 'false'. Default: 'true'.

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -17,6 +17,7 @@
 #   to in the package resource.
 # - $package_name is the name of the package you want to install. Required if
 #   $install_from_source is false.
+# - $package_options to pass extra options to the package resource.
 define tomcat::instance (
   $catalina_home          = undef,
   $catalina_base          = undef,
@@ -25,6 +26,7 @@ define tomcat::instance (
   $source_strip_first_dir = undef,
   $package_ensure         = undef,
   $package_name           = undef,
+  $package_options        = undef,
 ) {
 
   if $install_from_source {
@@ -74,7 +76,8 @@ define tomcat::instance (
     }
   } else {
     tomcat::instance::package { $package_name:
-      package_ensure => $package_ensure,
+      package_ensure  => $package_ensure,
+      package_options => $package_options,
     }
   }
 

--- a/manifests/instance/package.pp
+++ b/manifests/instance/package.pp
@@ -5,9 +5,11 @@
 # Parameters:
 # - $package_ensure is the ensure passed to the package resource.
 # - The $package_name you want to install.
+# - $package_options to pass extra options to the package resource.
 define tomcat::instance::package (
-  $package_ensure = 'installed',
-  $package_name = undef,
+  $package_ensure  = 'installed',
+  $package_name    = undef,
+  $package_options = undef,
 ) {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
@@ -20,7 +22,8 @@ define tomcat::instance::package (
   }
 
   package { $_package_name:
-    ensure => $package_ensure
+    ensure          => $package_ensure,
+    install_options => $package_options,
   }
 
 }

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -65,6 +65,21 @@ describe 'tomcat::instance', :type => :define do
       'ensure' => 'installed',
     )
     }
+    context "with additional package_options set" do
+      let :params do
+        {
+          :install_from_source => false,
+          :package_name        => 'tomcat',
+          :package_options     => [ '/S' ],
+        }
+      end
+      it {
+        is_expected.to contain_package('tomcat').with(
+          'ensure'          => 'installed',
+          'install_options' => [ '/S' ],
+        )
+      }
+    end
   end
   context "install from package, set $catalina_base" do
     let :facts do default_facts end


### PR DESCRIPTION
Based on the code by simontrimboy <simon.trimboy@capgemini.com>:

  * renamed the option to match the pattern of the other options in the define
  * added README entry
  * added a unit test