### PR TITLE
Split CATALINA_BASE as separate from, but supported by, CATALINA_HOME

### DIFF
--- a/manifests/config/context/resourcelink.pp
+++ b/manifests/config/context/resourcelink.pp
@@ -1,0 +1,61 @@
+# Definition tomcat::config::context::resourcelink
+#
+# Configure a ResourceLink element in $CATALINA_BASE/conf/context.xml
+#
+# Parameters:
+# - $catalina_base is the root of the Tomcat installation
+# - $resourceLink_ensure specifies whether you are trying to add or remove the resourceLink
+#   element. Valid values are 'true', 'false', 'present', or 'absent'. Defaults
+#   to 'present'.
+# - An optional hash of $additional_attributes to add to the Context. Should be of
+#   the format 'attribute' => 'value'.
+# - An optional array of $attributes_to_remove from the Context.
+#
+define tomcat::config::context::resourcelink (
+  $catalina_base         = $::tomcat::catalina_home,
+  $context_ensure        = 'present',
+  $additional_attributes = {},
+  $attributes_to_remove  = [],
+  $context_config         = undef,
+) {
+  if versioncmp($::augeasversion, '1.0.0') < 0 {
+    fail('Context configurations require Augeas >= 1.0.0')
+  }
+
+  validate_re($context_ensure, '^(present|absent|true|false)$')
+  validate_hash($additional_attributes)
+  validate_array($attributes_to_remove)
+
+  if $context_config {
+    $_context_config = $server_config
+  } else {
+    $_context_config = "${catalina_base}/conf/context.xml"
+  }
+
+  $path = "Context/ResourceLink[#attribute/name='${name}']"
+  if $context_ensure =~ /^(absent|false)$/ {
+    $augeaschanges = "rm ${path}"
+  } else {
+    $context = "set ${path}/#attribute/name ${name}"
+
+    if ! empty($additional_attributes) {
+      $_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${path}/#attribute/"), "'")
+    } else {
+      $_additional_attributes = undef
+    }
+
+    if ! empty(any2array($attributes_to_remove)) {
+      $_attributes_to_remove = prefix(any2array($attributes_to_remove), "rm ${path}/#attribute/")
+    } else {
+      $_attributes_to_remove = undef
+    }
+
+    $augeaschanges = delete_undef_values(flatten([$context, $_additional_attributes, $_attributes_to_remove]))
+  }
+
+  augeas { "${catalina_base}-${_parent_service}-${_parent_engine}-${parent_host}-context-${name}":
+    lens    => 'Xml.lns',
+    incl    => $_context_config,
+    changes => $augeaschanges,
+  }
+}

--- a/manifests/config/properties.pp
+++ b/manifests/config/properties.pp
@@ -7,7 +7,11 @@ define tomcat::config::properties (
   $srcfile = 'conf/catalina.properties',
 ) {
   concat { "${catalina_base}/${file}":
-    ensure => present,
+    ensure         => present,
+    ensure_newline => true,
+    owner          => $::tomcat::user,
+    group          => $::tomcat::group,
+    mode           => '0640',
   }
   concat::fragment { "${catalina_base} properties base file from catalina_home ${$catalina_home}/${srcfile}":
     target => "${catalina_base}/${file}",

--- a/manifests/config/properties.pp
+++ b/manifests/config/properties.pp
@@ -1,0 +1,17 @@
+## manage the catalina.properties file
+
+define tomcat::config::properties (
+  $catalina_base,
+  $catalina_home,
+  $file    = 'conf/catalina.properties',
+  $srcfile = 'conf/catalina.properties',
+) {
+  concat { "${catalina_base}/${file}":
+    ensure => present,
+  }
+  concat::fragment { "${catalina_base} properties base file from catalina_home ${$catalina_home}/${srcfile}":
+    target => "${catalina_base}/${file}",
+    source => "${catalina_home}/${srcfile}",
+    order  => 01,
+  }
+}

--- a/manifests/config/properties/property.pp
+++ b/manifests/config/properties/property.pp
@@ -1,0 +1,13 @@
+## manage an entry for the properties file, typically catalina.properties
+define tomcat::config::properties::property (
+  $catalina_base,
+  $value,
+  $property = $name,
+  $section  = 'default',
+  $file     = 'conf/catalina.properties',
+) {
+  concat::fragment { "${section} ${property}":
+    target  => "${catalina_base}/${file}",
+    content => "${property}=${value}",
+  }
+}

--- a/manifests/config/server/globalnamingresource.pp
+++ b/manifests/config/server/globalnamingresource.pp
@@ -1,0 +1,57 @@
+# Definition: tomcat::config::server::globalnamingresource
+#
+# Configure GlobalNamingResources Resource elements in $CATALINA_BASE/conf/server.xml
+#
+# Parameters:
+# - $catalina_base is the base directory for the Tomcat installation.
+# - $resource_ensure specifies whether you are trying to add or remove the
+#   Resource element. Valid values are 'true', 'false', 'present', and
+#   'absent'. Defaults to 'present'.
+# - An optional hash of $additional_attributes to add to the Resource. Should
+#   be of the format 'attribute' => 'value'.
+# - An optional array of $attributes_to_remove from the Resource.
+define tomcat::config::server::globalnamingresource (
+  $catalina_base         = $::tomcat::catalina_home,
+  $resource_ensure      = 'present',
+  $additional_attributes = {},
+  $attributes_to_remove  = [],
+  $server_config         = undef,
+) {
+  if versioncmp($::augeasversion, '1.0.0') < 0 {
+    fail('Server configurations require Augeas >= 1.0.0')
+  }
+
+  validate_re($resource_ensure, '^(present|absent|true|false)$')
+  validate_hash($additional_attributes)
+  validate_re($catalina_base, '^.*[^/]$', '$catalina_base must not end in a /!')
+
+  if $server_config {
+    $_server_config = $server_config
+  } else {
+    $_server_config = "${catalina_base}/conf/server.xml"
+  }
+
+  $base_path = "Server/GlobalNamingResources/Resource[#attribute/name='${name}']"
+  if $resource_ensure =~ /^(absent|false)$/ {
+    $changes = "rm ${base_path}"
+  } else {
+    if ! empty($additional_attributes) {
+      $_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${base_path}/#attribute/"), "'")
+    } else {
+      $_additional_attributes = undef
+    }
+    if ! empty(any2array($attributes_to_remove)) {
+      $_attributes_to_remove = prefix(any2array($attributes_to_remove), "rm ${base_path}/#attribute/")
+    } else {
+      $_attributes_to_remove = undef
+    }
+
+    $changes = delete_undef_values(flatten([ $_additional_attributes, $_attributes_to_remove ]))
+  }
+
+  augeas { "server-${catalina_base}-globalresource-${name}":
+    lens    => 'Xml.lns',
+    incl    => $_server_config,
+    changes => $changes,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,14 +48,6 @@ class tomcat (
     default: { }
   }
 
-  if $install_from_source {
-    file { $catalina_home:
-      ensure => directory,
-      owner  => $user,
-      group  => $group,
-    }
-  }
-
   if $manage_user {
     user { $user:
       ensure => present,

--- a/manifests/instance/conf_copy_from_home.pp
+++ b/manifests/instance/conf_copy_from_home.pp
@@ -1,0 +1,18 @@
+# Definition: tomcat::instance::conf_copy_from_home
+#
+# Private define to copy a conf file from catalina_home to catalina_base
+#
+define tomcat::instance::conf_copy_from_home (
+  $catalina_base,
+  $catalina_home,
+  $replace       = false,
+  $user          = $::tomcat::user,
+  $group         = $::tomcat::group,
+) {
+  file { "${catalina_base}/conf/${title}":
+    mode    => '0660',
+    source  => "${catalina_home}/conf/${title}",
+    require => File["${catalina_base}/conf"],
+    replace => $replace,
+  }
+}

--- a/manifests/instance/source.pp
+++ b/manifests/instance/source.pp
@@ -36,9 +36,9 @@ define tomcat::instance::source (
 
   staging::extract { "${name}-${filename}":
     source  => "${::staging::path}/tomcat/${filename}",
-    target  => $catalina_base,
+    target  => $catalina_home,
     require => Staging::File[$filename],
-    unless  => "test \"\$(ls -A ${catalina_base})\"",
+    unless  => "test \"\$(ls -A ${catalina_home})\"",
     user    => $::tomcat::user,
     group   => $::tomcat::group,
     strip   => $_strip,

--- a/manifests/setenv/entry.pp
+++ b/manifests/setenv/entry.pp
@@ -17,9 +17,10 @@ define tomcat::setenv::entry (
   $config_file = "${::tomcat::catalina_home}/bin/setenv.sh",
   $param       = $name,
   $quote_char  = undef,
+  $order       = 10,
+  $addto       = undef,
   # Deprecated
   $base_path   = undef,
-  $order       = 10,
 ) {
 
   if $base_path {
@@ -42,11 +43,15 @@ define tomcat::setenv::entry (
       ensure_newline => true,
     }
   }
-
+  if $addto {
+    $_content = inline_template('export <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char %> ; export <%= @addto %>="$<%= @addto %> $<%= @param %>"')
+  } else {
+    $_content = inline_template('export <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char %>')
+  }
   concat::fragment { "setenv-${name}":
     ensure  => $ensure,
     target  => $_config_file,
-    content => inline_template('export <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char %>'),
+    content => $_content,
     order   => $order,
   }
 }

--- a/templates/jsvc-init.erb
+++ b/templates/jsvc-init.erb
@@ -1,0 +1,232 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Make sure only root is running this script
+if [ "$(id -u)" != "0" ]; then
+  echo "This script must be run as root" 1>&2
+  exit 1
+fi
+
+ARG0="$0"
+PROGRAM="`basename $ARG0`"
+
+cygwin=false;
+darwin=false;
+case "`uname`" in
+  CYGWIN*)
+    cygwin=true
+  ;;
+  Darwin*)
+    darwin=true
+  ;;
+esac
+
+CATALINA_BASE=<%= _catalina_base %>
+CATALINA_HOME=<%= _catalina_home %>
+JAVA_HOME=<%= java_home %>
+TOMCAT_USER=<%= user %>
+
+# Use the maximum available, or set MAX_FD != -1 to use that
+test ".$MAX_FD" = . && MAX_FD="maximum"
+# Setup parameters for running the jsvc
+#
+test ".$TOMCAT_USER" = . && TOMCAT_USER=tomcat
+
+JAVA_BIN="$JAVA_HOME/bin/java"
+
+test ".$CATALINA_MAIN" = . && CATALINA_MAIN=org.apache.catalina.startup.Bootstrap
+test ".$JSVC" = . && JSVC="$CATALINA_BASE/bin/jsvc"
+## would be good to test the jsvc is from a valid common-daemon and for the correct java but how to do that
+
+# Ensure that any user defined CLASSPATH variables are not used on startup,
+# but allow them to be specified in setenv.sh, in rare case when it is needed.
+CLASSPATH=
+JAVA_OPTS=
+if [ -r "$CATALINA_BASE/bin/setenv.sh" ]; then
+  . "$CATALINA_BASE/bin/setenv.sh"
+elif [ -r "$CATALINA_HOME/bin/setenv.sh" ]; then
+  . "$CATALINA_HOME/bin/setenv.sh"
+fi
+
+## user set values are set now
+echo CATALINA_BASE $CATALINA_BASE
+echo CATALINA_HOME $CATALINA_HOME
+echo CATALINA_LOCAL $CATALINA_LOCAL
+echo -n CATALINA_OPTS
+echo " $CATALINA_OPTS" | sed -e 's/ -/\n    -/g' | sort
+echo -n JAVA_OPTS
+echo " $JAVA_OPTS" | sed -e 's/ -/\n    -/g' | sort
+echo TOMCAT_USER $TOMCAT_USER
+
+# Add on extra jar files to CLASSPATH
+test ".$CLASSPATH" != . && CLASSPATH="${CLASSPATH}:"
+CLASSPATH="$CLASSPATH$CATALINA_HOME/bin/bootstrap.jar:$CATALINA_HOME/bin/commons-daemon.jar"
+
+test ".$CATALINA_OUT" = . && CATALINA_OUT="$CATALINA_BASE/logs/catalina-daemon.out"
+test ".$CATALINA_TMP" = . && CATALINA_TMP="$CATALINA_BASE/temp"
+
+# Add tomcat-juli.jar to classpath
+# tomcat-juli.jar can be over-ridden per instance
+if [ -r "$CATALINA_BASE/bin/tomcat-juli.jar" ] ; then
+  CLASSPATH="$CLASSPATH:$CATALINA_BASE/bin/tomcat-juli.jar"
+else
+  CLASSPATH="$CLASSPATH:$CATALINA_HOME/bin/tomcat-juli.jar"
+fi
+# Set juli LogManager config file if it is present and an override has not been issued
+if [ -z "$LOGGING_CONFIG" ]; then
+  if [ -r "$CATALINA_BASE/conf/logging.properties" ]; then
+    LOGGING_CONFIG="-Djava.util.logging.config.file=$CATALINA_BASE/conf/logging.properties"
+  else
+    # Bugzilla 45585
+    LOGGING_CONFIG="-Dnop"
+  fi
+fi
+
+test ".$LOGGING_MANAGER" = . && LOGGING_MANAGER="-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager"
+JAVA_OPTS="$JAVA_OPTS $LOGGING_MANAGER"
+
+# Set -pidfile
+test ".$CATALINA_PID" = . && CATALINA_PID="$CATALINA_BASE/logs/catalina-daemon.pid"
+
+# Increase the maximum file descriptors if we can
+if [ "$cygwin" = "false" ]; then
+  MAX_FD_LIMIT=`ulimit -H -n`
+  if [ "$?" -eq 0 ]; then
+    # Darwin does not allow RLIMIT_INFINITY on file soft limit
+    if [ "$darwin" = "true" -a "$MAX_FD_LIMIT" = "unlimited" ]; then
+      MAX_FD_LIMIT=`/usr/sbin/sysctl -n kern.maxfilesperproc`
+    fi
+    test ".$MAX_FD" = ".maximum" && MAX_FD="$MAX_FD_LIMIT"
+    ulimit -n $MAX_FD
+    if [ "$?" -ne 0 ]; then
+      echo "$PROGRAM: Could not set maximum file descriptor limit: $MAX_FD"
+    fi
+  else
+    echo "$PROGRAM: Could not query system maximum file descriptor limit: $MAX_FD_LIMIT"
+  fi
+fi
+
+JSVC_OPTS="$JSVC_OPTS -umask 0027"
+
+do_start()
+{
+  "$JSVC" $JSVC_OPTS \
+    -java-home "$JAVA_HOME" \
+    -user "$TOMCAT_USER" \
+    -pidfile "$CATALINA_PID" \
+    -wait 10 \
+    -outfile "SYSLOG" \
+    -errfile "SYSLOG" \
+    -classpath "$CLASSPATH" \
+    "$LOGGING_CONFIG" $JAVA_OPTS $CATALINA_OPTS \
+    -Dcatalina.base="$CATALINA_BASE" \
+    -Dcatalina.home="$CATALINA_HOME" \
+    -Djava.io.tmpdir="$CATALINA_TMP" \
+    $CATALINA_MAIN
+  #exit $?
+}
+
+do_status()
+{
+  [ ! -f "$CATALINA_PID" ] && exit 3
+  [ "$(pgrep --list-name --pidfile "$CATALINA_PID")" != "$(cat $CATALINA_PID) jsvc" ] && exit 1
+  exit 0
+}
+
+do_stop()
+{
+  "$JSVC" $JSVC_OPTS \
+    -stop \
+    -pidfile "$CATALINA_PID" \
+    -classpath "$CLASSPATH" \
+    -Dcatalina.base="$CATALINA_BASE" \
+    -Dcatalina.home="$CATALINA_HOME" \
+    -Djava.io.tmpdir="$CATALINA_TMP" \
+    $CATALINA_MAIN
+  #exit $?
+}
+
+do_version()
+{
+  "$JSVC" \
+     -java-home "$JAVA_HOME" \
+     -pidfile "$CATALINA_PID" \
+     -classpath "$CLASSPATH" \
+     -outfile "SYSLOG" \
+     -errfile "SYSLOG" \
+     -version \
+     -check \
+     $CATALINA_MAIN
+  if [ "$?" = 0 ]; then
+    "$JAVA_BIN" \
+      -classpath "$CATALINA_HOME/lib/catalina.jar" \
+      org.apache.catalina.util.ServerInfo
+  fi
+  exit $?
+}
+
+# ----- Execute The Requested Command -----------------------------------------
+case "$1" in
+  run )
+    shift
+      "$JSVC" $* \
+      $JSVC_OPTS \
+      -java-home "$JAVA_HOME" \
+      -user "$TOMCAT_USER" \
+      -pidfile "$CATALINA_PID" \
+      -wait 10 \
+      -nodetach \
+      -outfile "&1" \
+      -errfile "&2" \
+      -classpath "$CLASSPATH" \
+      "$LOGGING_CONFIG" $JAVA_OPTS $CATALINA_OPTS \
+      -Dcatalina.base="$CATALINA_BASE" \
+      -Dcatalina.home="$CATALINA_HOME" \
+      -Djava.io.tmpdir="$CATALINA_TMP" \
+      $CATALINA_MAIN
+    exit $?
+    ;;
+  start )
+    do_start
+  ;;
+  stop )
+    do_stop
+  ;;
+  status )
+    do_status
+  ;;
+  restart )
+    do_stop
+    do_start
+  ;;
+  version )
+    do_version
+  ;;
+  * )
+    echo "Unknown command: '$1'"
+    echo "Usage: $PROGRAM ( commands ... )"
+    echo "commands:"
+    echo "  restart           Restart Catalina"
+    echo "  run               Start Catalina without detaching from console"
+    echo "  start             Start Catalina"
+    echo "  status            Report if JSVC is running"
+    echo "  stop              Stop Catalina"
+    echo "  version           What version of commons daemon and Tomcat"
+    echo "                    are you running?"
+    exit 1
+  ;;
+esac


### PR DESCRIPTION
This replaces "#108 support catalina_base properly"

The intent is that CATALINA_BASE is separate from CATALINA_HOME

with this request CATALINA_HOME is where the apache-tomcat source is extracted to and CATALINA_BASE is where it is configured, where webapps are to be placed and where instances files (log, temp/work files) will be created

Master also includes
* properties for catalina.properties (this is copied from CATALINA_HOME and others added as tomcat needs some of the settings from it)
* jsvc-init - a init file for jsvc
* support setenv adding parts to a common variable (CATALINA_OPTS often wants many things added from different sources)
* global naming resource - (I use it for database connections)
* resourceLink in context.xml

Would these be easier to accept as individual PRs?