### PR TITLE
delete realm nodes in depth-first order to workaround augeas segfault

### DIFF
--- a/manifests/config/server/realm.pp
+++ b/manifests/config/server/realm.pp
@@ -46,7 +46,15 @@ define tomcat::config::server::realm (
   }
 
   if $purge_realms {
-    $_purge_realms = 'rm Server//Realm'
+    # Perform deletions in reverse depth order as workaround for
+    # https://github.com/hercules-team/augeas/issues/319
+    $_purge_realms = [
+      'rm //Realm//Realm',
+      'rm //Context//Realm',
+      'rm //Host//Realm',
+      'rm //Engine//Realm',
+      'rm //Server//Realm',
+    ]
   } else {
     $_purge_realms = undef
   }

--- a/spec/defines/config/server/realm_spec.rb
+++ b/spec/defines/config/server/realm_spec.rb
@@ -70,7 +70,11 @@ describe 'tomcat::config::server::realm', :type => :define do
       'lens' => 'Xml.lns',
       'incl' => '/opt/apache-tomcat/test/conf/server.xml',
       'changes' => [
-        "rm Server//Realm",
+        "rm //Realm//Realm",
+        "rm //Context//Realm",
+        "rm //Host//Realm",
+        "rm //Engine//Realm",
+        "rm //Server//Realm",
         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm/#attribute/className org.apache.catalina.realm.JNDIRealm",
         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/connectionURL 'ldap://localhost'",
         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/roleName 'cn'",


### PR DESCRIPTION
Several reports have come in from customers experiencing segfaults from augeas during puppet runs when using the tomcat module.

Modules ticket:  https://tickets.puppetlabs.com/browse/MODULES-1721

I've captured a full description of the problem with agueas over at https://github.com/hercules-team/augeas/issues/319 but fixing this properly is going to involve a new release of the augeas library and therefore a new puppet-agent release.

This PR fixes the segfault by performing a depth-first deletion of all `Realm` elements.