### PR TITLE
MODULES-2984 - Add support for host aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 .idea/
 *.iml
 log/
+.project

--- a/README.md
+++ b/README.md
@@ -437,6 +437,10 @@ Specifies whether the [startStopThreads XML attribute](http://tomcat.apache.org/
 
 Specifies any further attributes to add to the Host. Valid options: a hash of '< attribute >' => '< value >' pairs. Default: {}.
 
+#####`aliases`
+
+Optional array that specifies the list of [Host Name Aliases](http://tomcat.apache.org/tomcat-8.0-doc/config/host.html#Host_Name_Aliases) for this particular Host.  If omitted, any currently-defined Aliases will not be altered.  If present, the list Aliases  will be set to exactly match the contents of this array.  Thus, for example, an empty array can be used to explicity force there to be no Aliases for the Host.
+
 #####`app_base`
 
 *Required unless [`host_ensure`](#host_ensure) is set to 'false' or 'absent'.* Specifies the Application Base directory for the virtual host. Maps to the [appBase XML attribute](http://tomcat.apache.org/tomcat-8.0-doc/config/host.html#Common_Attributes). Valid options: a string.

--- a/spec/defines/config/server/host_spec.rb
+++ b/spec/defines/config/server/host_spec.rb
@@ -48,6 +48,11 @@ describe 'tomcat::config::server::host', :type => :define do
           'bar',
           'baz',
         ],
+        :aliases              => [
+          'able',
+          'baker',
+          'charlie',
+        ],
       }
     end
     it { is_expected.to contain_augeas('/opt/apache-tomcat/test-Catalina2-host-test.example.com').with(
@@ -62,6 +67,28 @@ describe 'tomcat::config::server::host', :type => :define do
         'rm Server/Service[#attribute/name=\'Catalina2\']/Engine/Host[#attribute/name=\'test.example.com\']/#attribute/foo',
         'rm Server/Service[#attribute/name=\'Catalina2\']/Engine/Host[#attribute/name=\'test.example.com\']/#attribute/bar',
         'rm Server/Service[#attribute/name=\'Catalina2\']/Engine/Host[#attribute/name=\'test.example.com\']/#attribute/baz',
+        'rm Server/Service[#attribute/name=\'Catalina2\']/Engine/Host[#attribute/name=\'test.example.com\']/Alias',
+        'set Server/Service[#attribute/name=\'Catalina2\']/Engine/Host[#attribute/name=\'test.example.com\']/Alias[last()+1]/#text \'able\'',
+        'set Server/Service[#attribute/name=\'Catalina2\']/Engine/Host[#attribute/name=\'test.example.com\']/Alias[last()+1]/#text \'baker\'',
+        'set Server/Service[#attribute/name=\'Catalina2\']/Engine/Host[#attribute/name=\'test.example.com\']/Alias[last()+1]/#text \'charlie\'',
+      ]
+    )
+    }
+  end
+  context 'empty array of aliases removes old aliases and does not add any' do
+    let :params do
+      {
+        :app_base => 'webapps',
+        :aliases  => [],
+      }
+    end
+    it { is_expected.to contain_augeas('/opt/apache-tomcat-Catalina-host-localhost').with(
+      'lens' => 'Xml.lns',
+      'incl' => '/opt/apache-tomcat/conf/server.xml',
+      'changes' => [
+        'set Server/Service[#attribute/name=\'Catalina\']/Engine/Host[#attribute/name=\'localhost\']/#attribute/name localhost',
+        'set Server/Service[#attribute/name=\'Catalina\']/Engine/Host[#attribute/name=\'localhost\']/#attribute/appBase webapps',
+        'rm Server/Service[#attribute/name=\'Catalina\']/Engine/Host[#attribute/name=\'localhost\']/Alias',
       ]
     )
     }
@@ -111,6 +138,19 @@ describe 'tomcat::config::server::host', :type => :define do
         expect {
           catalogue
         }.to raise_error(Puppet::Error, /does not match/)
+      end
+    end
+    context 'invalid aliases' do
+      let :params do
+        {
+          :app_base => 'webapps',
+          :aliases => 'not_an_array',
+        }
+      end
+      it do
+        expect {
+          catalogue
+        }.to raise_error(Puppet::Error, /is not an Array/)
       end
     end
     context 'old augeas' do


### PR DESCRIPTION
Proposed implementation for MODULES-2984 (Adding support for management of Host Name Aliases)

Modifications:
.gitignore - ignore the .project file that Geppetto creates
manifests/config/server/host.pp - Implementation of the new feature
spec/defines/config/server/host_spec.rb - test cases for:
    - Adding a set of aliases
    - Removing any existing aliases by specifying an empty array as the parameter
    - Ensuring that the parameter (if provided) is an array
README.md - document the new feature

