### PR TITLE
(MODULES-3117) User and Group bugfix to support setting via tomcat::i…

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -83,6 +83,8 @@ define tomcat::instance (
       catalina_home          => $_catalina_home,
       source_url             => $source_url,
       source_strip_first_dir => $source_strip,
+      user                   => $user,
+      group                  => $group,
       require                => File[$_catalina_base],
     }
     if $_catalina_home != $_catalina_base {

--- a/manifests/instance/source.pp
+++ b/manifests/instance/source.pp
@@ -9,10 +9,17 @@
 #   the first directory when unpacking the source tarball. Defaults to true
 #   when installing from source on non-Solaris systems. Requires nanliu/staging
 #   > 0.4.0
+# - $user is the user that the package should be installed under, default to tomcat
+#   class defined user
+# - $group is the group that the package should be installed under, default to tomcat
+#   class defined group
+
 define tomcat::instance::source (
   $catalina_home,
   $source_url,
   $source_strip_first_dir = undef,
+  $user = $::tomcat::user,
+  $group = $::tomcat::group,
 ) {
   include staging
 
@@ -37,8 +44,8 @@ define tomcat::instance::source (
     target  => $catalina_home,
     require => Staging::File[$filename],
     unless  => "test \"\$(ls -A ${catalina_home})\"",
-    user    => $::tomcat::user,
-    group   => $::tomcat::group,
+    user    => $user,
+    group   => $group,
     strip   => $_strip,
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -108,7 +108,7 @@ define tomcat::service (
     } elsif $_catalina_base == $_catalina_home {
       $_start = "export CATALINA_HOME=${_catalina_home}; export CATALINA_BASE=${_catalina_base}; \
                  \$CATALINA_BASE/bin/jsvc \
-                   ${_jsvc_home}-user ${::tomcat::user} \
+                   ${_jsvc_home}-user ${user} \
                    -classpath \$CATALINA_BASE/bin/bootstrap.jar:\$CATALINA_BASE/bin/tomcat-juli.jar \
                    -outfile \$CATALINA_BASE/logs/catalina.out \
                    -errfile \$CATALINA_BASE/logs/catalina.err \
@@ -146,11 +146,11 @@ define tomcat::service (
     $_hasstatus    = false
     $_hasrestart   = false
     $_start        = $start_command ? {
-      undef   => "su -s /bin/bash -c '${_catalina_base}/bin/catalina.sh start' ${::tomcat::user}",
+      undef   => "su -s /bin/bash -c '${_catalina_base}/bin/catalina.sh start' ${user}",
       default => $start_command
     }
     $_stop         = $stop_command ? {
-      undef   => "su -s /bin/bash -c '${_catalina_base}/bin/catalina.sh stop' ${::tomcat::user}",
+      undef   => "su -s /bin/bash -c '${_catalina_base}/bin/catalina.sh stop' ${user}",
       default => $stop_command
     }
     $_status       = "ps aux | grep 'catalina.base=${_catalina_base} ' | grep -v grep"


### PR DESCRIPTION
(MODULES-3117) User and Group bugfix to support setting via tomcat::instance and starting the service.

Previously setting the user and group can only be done once via the tomcat class. It appears there has been some work to support setting the user and group in tomcat::instance but some other changes had to be made so the service would start up correctly with the user set in the instance.

The change defaults to the user and group set in the tomcat class, but can use the tomcat instance variables if those have been set.