### PR TITLE
Fix for older concats

### DIFF
--- a/manifests/setenv/entry.pp
+++ b/manifests/setenv/entry.pp
@@ -18,7 +18,7 @@ define tomcat::setenv::entry (
   $config_file   = undef,
   $param         = $name,
   $quote_char    = undef,
-  $order         = 10,
+  $order         = '10',
   $addto         = undef,
   # Deprecated
   $base_path     = undef,

--- a/spec/defines/setenv/entry_spec.rb
+++ b/spec/defines/setenv/entry_spec.rb
@@ -97,7 +97,7 @@ describe 'tomcat::setenv::entry', :type => :define do
       {
         'param' => 'BAR',
         'value' => '/bin/true',
-        'order' => 10,
+        'order' => '10',
       }
     end
 
@@ -105,7 +105,7 @@ describe 'tomcat::setenv::entry', :type => :define do
     it { is_expected.to contain_concat__fragment('setenv-FOO').with_content(/export BAR=\/bin\/true/).with({
       'ensure' => 'present',
       'target' => '/opt/apache-tomcat/bin/setenv.sh',
-      'order'  => 10,
+      'order'  => '10',
     })
     }
   end


### PR DESCRIPTION
Older concats need order to be a string, not an integer.