### PR TITLE
Update documentation and fix bugs

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -34,7 +34,7 @@ define tomcat::instance (
   $use_jsvc               = undef,
   $use_init               = undef,
 
-  #used for single installs
+  #used for single installs. Deprecated?
   $install_from_source    = undef,
   $source_url             = undef,
   $source_strip_first_dir = undef,
@@ -94,8 +94,7 @@ define tomcat::instance (
       package_name           => $package_name,
       package_options        => $package_options,
     }
-    # XXX The user always has to declare the service
-    $_manage_service = false
+    $_manage_service = pick($manage_service, false)
   } else {
     if $_catalina_home != $_catalina_base {
       if $_manage_user {
@@ -152,8 +151,8 @@ define tomcat::instance (
         user          => $_user,
         group         => $_group,
       }
-      $_manage_service = pick($manage_service, true)
     }
+    $_manage_service = pick($manage_service, true)
   }
   if $_manage_service {
     tomcat::service { $name:

--- a/manifests/instance/dependencies.pp
+++ b/manifests/instance/dependencies.pp
@@ -7,41 +7,41 @@ define tomcat::instance::dependencies (
   $base_sha = sha1($catalina_base)
 
   Tomcat::Install                      <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Service                   <| tag == $base_sha or tag == $home_sha |>
+  -> Tomcat::Service                   <| tag == $base_sha |>
 
   Tomcat::Install                      <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Instance::Copy_from_home  <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Service                   <| tag == $base_sha or tag == $home_sha |>
+  -> Tomcat::Instance::Copy_from_home  <| tag == $base_sha |>
+  -> Tomcat::Service                   <| tag == $base_sha |>
 
   Tomcat::Install                      <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Config::Properties        <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Service                   <| tag == $base_sha or tag == $home_sha |>
-  Tomcat::Instance::Copy_from_home     <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Config::Properties        <| tag == $base_sha or tag == $home_sha |>
+  -> Tomcat::Service                   <| tag == $base_sha |>
+  -> Tomcat::Config::Properties        <| tag == $base_sha |>
+  Tomcat::Instance::Copy_from_home     <| tag == $base_sha |>
+  -> Tomcat::Config::Properties        <| tag == $base_sha |>
 
   Tomcat::Install                      <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Config::Server            <| tag == $base_sha or tag == $home_sha |>
-  ~> Tomcat::Service                   <| tag == $base_sha or tag == $home_sha |>
-  Tomcat::Instance::Copy_from_home     <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Config::Server            <| tag == $base_sha or tag == $home_sha |>
+  -> Tomcat::Config::Server            <| tag == $base_sha |>
+  ~> Tomcat::Service                   <| tag == $base_sha |>
+  Tomcat::Instance::Copy_from_home     <| tag == $base_sha |>
+  -> Tomcat::Config::Server            <| tag == $base_sha |>
 
   Tomcat::Install                      <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Config::Server::Realm     <| tag == $base_sha or tag == $home_sha |>
-  ~> Tomcat::Service                   <| tag == $base_sha or tag == $home_sha |>
-  Tomcat::Instance::Copy_from_home     <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Config::Server::Realm     <| tag == $base_sha or tag == $home_sha |>
+  -> Tomcat::Config::Server::Realm     <| tag == $base_sha |>
+  ~> Tomcat::Service                   <| tag == $base_sha |>
+  Tomcat::Instance::Copy_from_home     <| tag == $base_sha |>
+  -> Tomcat::Config::Server::Realm     <| tag == $base_sha |>
 
   Tomcat::Install                      <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Config::Server::Connector <| tag == $base_sha or tag == $home_sha |>
-  ~> Tomcat::Service                   <| tag == $base_sha or tag == $home_sha |>
-  Tomcat::Instance::Copy_from_home     <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Config::Server::Connector <| tag == $base_sha or tag == $home_sha |>
+  -> Tomcat::Config::Server::Connector <| tag == $base_sha |>
+  ~> Tomcat::Service                   <| tag == $base_sha |>
+  Tomcat::Instance::Copy_from_home     <| tag == $base_sha |>
+  -> Tomcat::Config::Server::Connector <| tag == $base_sha |>
 
   Tomcat::Install                      <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Setenv::Entry             <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Service                   <| tag == $base_sha or tag == $home_sha |>
+  -> Tomcat::Setenv::Entry             <| tag == $base_sha |>
+  -> Tomcat::Service                   <| tag == $base_sha |>
 
   Tomcat::Install                      <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::War                       <| tag == $base_sha or tag == $home_sha |>
-  -> Tomcat::Service                   <| tag == $base_sha or tag == $home_sha |>
+  -> Tomcat::War                       <| tag == $base_sha |>
+  -> Tomcat::Service                   <| tag == $base_sha |>
 }

--- a/spec/acceptance/readme_spec.rb
+++ b/spec/acceptance/readme_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper_acceptance'
+
+#fact based two stage confine
+
+#confine array
+confine_array = [
+  (fact('operatingsystem') == 'Ubuntu'  &&  fact('operatingsystemrelease') == '10.04'),
+  (fact('osfamily') == 'RedHat'         &&  fact('operatingsystemmajrelease') == '5'),
+  (fact('operatingsystem') == 'Debian'  &&  fact('operatingsystemmajrelease') == '6'),
+  fact('osfamily') == 'Suse'
+]
+
+stop_test = false
+stop_test = true if UNSUPPORTED_PLATFORMS.any?{ |up| fact('osfamily') == up} || confine_array.any?
+
+describe 'README examples', :unless => stop_test do
+  after :all do
+    shell('pkill -f tomcat', :acceptable_exit_codes => [0,1])
+    shell('rm -rf /opt/tomcat*', :acceptable_exit_codes => [0,1])
+    shell('rm -rf /opt/apache-tomcat*', :acceptable_exit_codes => [0,1])
+  end
+
+  context 'Beginning with Tomcat' do
+    it 'Should apply the manifest without error' do
+      pp = <<-EOS
+      class{'java':}
+      tomcat::install { '/opt/tomcat':
+        source_url => 'http://www-us.apache.org/dist/tomcat/tomcat-7/v7.0.68/bin/apache-tomcat-7.0.68.tar.gz',
+      }
+      tomcat::instance { 'default':
+        catalina_home => '/opt/tomcat',
+      }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
+      shell('sleep 15')
+    end
+    it 'has the server running on port 8080' do
+      shell('curl localhost:8080', :acceptable_exit_codes => 0) do |r|
+        r.stdout.should match(/Apache Tomcat/)
+      end
+    end
+  end
+
+  context 'I want to run multiple instances of multiple versions of tomcat' do
+    it 'Should apply the manifest without error' do
+      pp = <<-EOS
+      EOS
+      apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
+      shell('sleep 15')
+    end
+    it 'Should not be serving a page on port 80' do
+      shell('curl localhost:80/war_one/hello.jsp', :acceptable_exit_codes => 7)
+    end
+  end
+
+  context 'Start Tomcat with verification' do
+    it 'Should apply the manifest without error' do
+      pp = <<-EOS
+      $java_home = $::osfamily ? {
+        'RedHat' => '/etc/alternatives/java_sdk',
+        'Debian' => "/usr/lib/jvm/java-7-openjdk-${::architecture}",
+        default  => undef
+      }
+
+      tomcat::service { 'jsvc-default':
+        service_ensure => running,
+        catalina_home  => '/opt/apache-tomcat',
+        catalina_base  => '/opt/apache-tomcat/tomcat8-jsvc',
+        use_jsvc       => true,
+        java_home      => $java_home,
+        user           => 'tomcat8',
+      }
+      EOS
+      apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
+      shell('sleep 15')
+    end
+    it 'Should be serving a page on port 80' do
+      shell('curl localhost:80/war_one/hello.jsp', :acceptable_exit_codes => 0) do |r|
+        r.stdout.should match(/Sample Application JSP Page/)
+      end
+    end
+  end
+
+  context 'un-deploy the war with verification' do
+    it 'Should apply the manifest without error' do
+      pp = <<-EOS
+      tomcat::war { 'war_one.war':
+        catalina_base => '/opt/apache-tomcat/tomcat8-jsvc',
+        war_source    => '#{SAMPLE_WAR}',
+        war_ensure    => absent,
+      }
+      EOS
+      apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
+      shell('sleep 15')
+    end
+    it 'Should not have deployed the war' do
+      shell('curl localhost:80/war_one/hello.jsp', :acceptable_exit_codes => 0) do |r|
+        r.stdout.should eq("")
+      end
+    end
+  end
+
+  context 'remove the connector with verification' do
+
+    it 'Should apply the manifest without error' do
+      pp = <<-EOS
+      $java_home = $::osfamily ? {
+        'RedHat' => '/etc/alternatives/java_sdk',
+        'Debian' => "/usr/lib/jvm/java-7-openjdk-${::architecture}",
+        default  => undef
+      }
+
+      tomcat::config::server::connector { 'tomcat8-jsvc':
+        connector_ensure => 'absent',
+        catalina_base    => '/opt/apache-tomcat/tomcat8-jsvc',
+        port             => '80',
+        notify           => Tomcat::Service['jsvc-default']
+      }
+      tomcat::service { 'jsvc-default':
+        service_ensure => running,
+        catalina_home  => '/opt/apache-tomcat',
+        catalina_base  => '/opt/apache-tomcat/tomcat8-jsvc',
+        java_home      => $java_home,
+        use_jsvc       => true,
+        user           => 'tomcat8',
+      }
+      EOS
+      apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
+      shell('sleep 15')
+    end
+    it 'Should not be able to serve pages over port 80' do
+      shell('curl localhost:80', :acceptable_exit_codes => 7)
+    end
+  end
+end


### PR DESCRIPTION
The documentation needed to be updated for the new define
tomcat::install and the documentation and usage around tomcat::instance
needed to be updated. The tests test the examples used in the readme.

The bugfixes:
- Fix logic for setting tomcat::instance::manage_service
- Reduce dependencies in multi-instance cases.