### PR TITLE
(maint) fix t::c::s::tomcat_users under strict variables

### DIFF
--- a/manifests/config/server/tomcat_users.pp
+++ b/manifests/config/server/tomcat_users.pp
@@ -76,16 +76,23 @@ define tomcat::config::server::tomcat_users (
   $path = "tomcat-users/${element}[#attribute/${element_identifier}='${_element_name}']"
 
   if $ensure =~ /^(absent|false)$/ {
+    $add_entry = undef
     $remove_entry = "rm ${path}"
+    $add_password = undef
+    $add_roles = undef
   } else {
     $add_entry = "set ${path}/#attribute/${element_identifier} '${_element_name}'"
+    $remove_entry = undef
     if $element == 'user' {
       $add_password = "set ${path}/#attribute/password '${password}'"
       $add_roles = join(["set ${path}/#attribute/roles '",join($roles, ','),"'"])
+    } else {
+      $add_password = undef
+      $add_roles = undef
     }
   }
 
-  $changes = delete_undef_values(flatten([$remove_entry, $add_entry, $add_password, $add_roles]))
+  $changes = delete_undef_values([$remove_entry, $add_entry, $add_password, $add_roles])
 
   augeas { "${catalina_base}-tomcat_users-${element}-${_element_name}-${name}":
     lens    => 'Xml.lns',


### PR DESCRIPTION
This also removes a unnecessary flatten() call. All the arguments are
strings or undef.