### PR TITLE
add tomcat::config::context::environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
         * [tomcat::config::server::tomcat_users](#tomcatconfigservertomcat_users)
         * [tomcat::config::server::valve](#tomcatconfigservervalve)
         * [tomcat::config::context](#tomcatconfigcontext)
+        * [tomcat::config::context::environment](#tomcatconfigcontextenvironment)
         * [tomcat::config::context::resource](#tomcatconfigcontextresource)
         * [tomcat::config::context::resourcelink](#tomcatconfigcontextresourcelink)
         * [tomcat::install](#tomcatinstall)
@@ -203,6 +204,7 @@ Puppet removes any existing Connectors or Realms and leaves only the ones you've
 * `tomcat::config::server::tomcat_users`: Configures user and role elements for [UserDatabaseRealm] (http://tomcat.apache.org/tomcat-8.0-doc/realm-howto.html#UserDatabaseRealm) or [MemoryRealm] (http://tomcat.apache.org/tomcat-8.0-doc/realm-howto.html#MemoryRealm) in `$CATALINA_BASE/conf/tomcat-users.xml` or any other specified file.
 * `tomcat::config::server::valve`: Configures a [Valve](http://tomcat.apache.org/tomcat-8.0-doc/config/valve.html) element in `$CATALINA_BASE/conf/server.xml`.
 * `tomcat::config::context`: Configures a [Context](http://tomcat.apache.org/tomcat-8.0-doc/config/context.html) element in $CATALINA_BASE/conf/context.xml.
+* `tomcat::config::context::environment`: Configures a [Environment](http://tomcat.apache.org/tomcat-8.0-doc/config/context.html#Environment_Entries) element in $CATALINA_BASE/conf/context.xml.
 * `tomcat::config::context::resource`: Configures a [Resource](http://tomcat.apache.org/tomcat-8.0-doc/config/context.html#Resource_Definitions) element in $CATALINA_BASE/conf/context.xml.
 * `tomcat::config::context::resourcelink`: Configures a [ResourceLink](http://tomcat.apache.org/tomcat-8.0-doc/config/context.html#Resource_Links) element in $CATALINA_BASE/conf/context.xml.
 * `tomcat::install`: Installs a Tomcat instance.
@@ -673,11 +675,53 @@ Specifies a server.xml file to manage. Valid options: a string containing an abs
 Specifies whether the Valve should exist in the configuration file. Maps to the  [Valve XML element](http://tomcat.apache.org/tomcat-8.0-doc/config/valve.html#Introduction). Valid options: 'true', 'false', 'present', and 'absent'. Default: 'present'.
 
 #### tomcat::config::context
+
 Specifies a configuration Context element in `${catalina_base}/conf/context.xml` for other `tomcat::config::context::*` defines.
 
 ##### `catalina_base`
 
 Specifies the root of the Tomcat installation.
+
+#### tomcat::config::context::environment
+
+Specifies Environment elements in `${catalina_base}/conf/context.xml`
+
+##### `ensure`
+
+Specifies whether you are trying to add or remove the Environment element. Valid values are 'true', 'false', 'present', and 'absent'. Defaults to 'present'
+
+##### `environment_name`
+
+The name of the Environment Entry to be created, relative to the java:comp/env context. Default: `$name`
+
+##### `type`
+
+The fully qualified Java class name expected by the web application for this environment entry. Required to create the environment entry.
+
+##### `value`
+
+The value that will be presented to the application when requested from the JNDI context. Required to create the environment entry.
+
+##### `description`
+
+The description is an an optional string for a human-readable description of this environment entry.
+
+##### `override`
+
+An optional string or boolean to specify if you do not want an <env-entry> for the same environment entry name to override the value specified here (set it to `false`).
+By default, overrides are allowed.
+
+##### `catalina_base`
+
+Specifies the root of the Tomcat installation. Default: `$tomcat::catalina_home`
+
+##### `additional_attributes`
+
+Specifies any additional attributes to add to the Environment. Should be a hash of the format 'attribute' => 'value'. This parameter is optional.
+
+##### `attributes_to_remove`
+
+Specifies any attributes to remove from the Environment. Should be a hash of the format 'attribute' => 'value'. This parameter is optional.
 
 #### tomcat::config::context::resource
 Specifies Resource elements in `${catalina_base}/conf/context.xml`

--- a/manifests/config/context/environment.pp
+++ b/manifests/config/context/environment.pp
@@ -1,0 +1,115 @@
+# Definition: tomcat::config::context::environment
+#
+# Configure Environment elements in $CATALINA_BASE/conf/context.xml
+#
+# Parameters:
+# - $ensure specifies whether you are trying to add or remove the
+#   Environment element. Valid values are 'true', 'false', 'present', and
+#   'absent'. Defaults to 'present'.
+# - $catalina_base is the base directory for the Tomcat installation.
+# - $environment_name is the name of the Environment to be created, relative to
+#   the java:comp/env context.
+# - $type is the fully qualified Java class name expected by the web application
+#   for this environment entry.
+# - $value that will be presented to the application when requested from
+#   the JNDI context.
+# - $description is an optional string for a human-readable description
+#   of this environment entry.
+# - Set $override to false if you do not want an <env-entry> for
+#   the same environment entry name to override the value specified here.
+# - An optional hash of $additional_attributes to add to the Environment. Should
+#   be of the format 'attribute' => 'value'.
+# - An optional array of $attributes_to_remove from the Environment.
+define tomcat::config::context::environment (
+  $ensure                  = 'present',
+  $catalina_base           = $::tomcat::catalina_home,
+  $environment_name        = $name,
+  $type                    = undef,
+  $value                   = undef,
+  $description             = undef,
+  $override                = undef,
+  $additional_attributes   = {},
+  $attributes_to_remove    = [],
+) {
+  if versioncmp($::augeasversion, '1.0.0') < 0 {
+    fail('Server configurations require Augeas >= 1.0.0')
+  }
+
+  if is_bool($override) {
+    $_override = bool2str($override)
+  } else {
+    $_override = $override
+  }
+
+  validate_re($ensure, '^(present|absent|true|false)$')
+  validate_absolute_path($catalina_base)
+
+  validate_string(
+    $environment_name,
+    $type,
+    $value,
+    $description,
+  )
+
+  validate_hash($additional_attributes)
+  validate_array($attributes_to_remove)
+
+  $base_path = "Context/Environment[#attribute/name='${environment_name}']"
+
+  if $ensure =~ /^(absent|false)$/ {
+    $changes = "rm ${base_path}"
+  } else {
+    if empty($type) {
+      fail('$type must be specified')
+    }
+
+    if empty($value) {
+      fail('$value must be specified')
+    }
+
+    $set_name  = "set ${base_path}/#attribute/name ${environment_name}"
+    $set_type  = "set ${base_path}/#attribute/type ${type}"
+    $set_value = "set ${base_path}/#attribute/value ${value}"
+
+    if ! empty($_override) {
+      validate_re($_override, '(true|false)', '$override must be true or false')
+      $set_override = "set ${base_path}/#attribute/override ${_override}"
+    } else {
+      $set_override = "rm ${base_path}/#attribute/override"
+    }
+
+    if ! empty($description) {
+      $set_description = "set ${base_path}/#attribute/description \'${description}\'"
+    } else {
+      $set_description = "rm ${base_path}/#attribute/description"
+    }
+
+    if ! empty($additional_attributes) {
+      $set_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${base_path}/#attribute/"), "'")
+    } else {
+      $set_additional_attributes = undef
+    }
+
+    if ! empty(any2array($attributes_to_remove)) {
+      $rm_attributes_to_remove = prefix(any2array($attributes_to_remove), "rm ${base_path}/#attribute/")
+    } else {
+      $rm_attributes_to_remove = undef
+    }
+
+    $changes = delete_undef_values(flatten([
+      $set_name,
+      $set_type,
+      $set_value,
+      $set_override,
+      $set_description,
+      $set_additional_attributes,
+      $rm_attributes_to_remove,
+    ]))
+  }
+
+  augeas { "context-${catalina_base}-environment-${name}":
+    lens    => 'Xml.lns',
+    incl    => "${catalina_base}/conf/context.xml",
+    changes => $changes,
+  }
+}

--- a/spec/defines/config/context/environment_spec.rb
+++ b/spec/defines/config/context/environment_spec.rb
@@ -1,0 +1,199 @@
+require 'spec_helper'
+
+describe 'tomcat::config::context::environment', :type => :define do
+  let :pre_condition do
+    'class {"tomcat": }'
+  end
+  let :facts do
+    {
+      :osfamily => 'Debian',
+      :augeasversion => '1.0.0'
+    }
+  end
+  let :title do
+    'maxExemptions'
+  end
+  context 'Add Environment' do
+    let :params do
+      {
+        :catalina_base         => '/opt/apache-tomcat/foo',
+        :environment_name      => 'maxExemptions',
+        :type                  => 'java.lang.Integer',
+        :value                 => '10',
+        :additional_attributes => {
+          'foo' => 'bar',
+          'bar' => 'foo',
+        },
+        :attributes_to_remove  => [
+          'foobar',
+          'barfoo',
+        ]
+      }
+    end
+    it { is_expected.to contain_augeas('context-/opt/apache-tomcat/foo-environment-maxExemptions').with(
+      'lens'    => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/foo/conf/context.xml',
+      'changes' => [
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/name maxExemptions',
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/type java.lang.Integer',
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/value 10',
+        'rm Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/override',
+        'rm Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/description',
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/foo \'bar\'',
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/bar \'foo\'',
+        'rm Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/foobar',
+        'rm Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/barfoo',
+      ]
+    )
+    }
+  end
+  context 'Remove Environment' do
+   let :params do
+     {
+       :catalina_base => '/opt/apache-tomcat/foo',
+       :ensure        => 'absent',
+     }
+   end
+   it { is_expected.to contain_augeas('context-/opt/apache-tomcat/foo-environment-maxExemptions').with(
+     'lens'    => 'Xml.lns',
+     'incl'    => '/opt/apache-tomcat/foo/conf/context.xml',
+     'changes' => [
+       'rm Context/Environment[#attribute/name=\'maxExemptions\']',
+       ]
+     )
+   }
+  end
+  context 'No environment_name' do
+    let :params do
+      {
+        :catalina_base => '/opt/apache-tomcat/foo',
+        :type          => 'java.lang.Integer',
+        :value         => '10',
+      }
+    end
+    it { is_expected.to contain_augeas('context-/opt/apache-tomcat/foo-environment-maxExemptions').with(
+      'lens'    => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/foo/conf/context.xml',
+      'changes' => [
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/name maxExemptions',
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/type java.lang.Integer',
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/value 10',
+        'rm Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/override',
+        'rm Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/description',
+        ]
+      )
+    }
+  end
+  context 'Set override' do
+    let :params do
+      {
+        :catalina_base => '/opt/apache-tomcat/foo',
+        :type          => 'java.lang.Integer',
+        :value         => '10',
+        :override      => 'true',
+      }
+    end
+    it { is_expected.to contain_augeas('context-/opt/apache-tomcat/foo-environment-maxExemptions').with(
+      'lens'    => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/foo/conf/context.xml',
+      'changes' => [
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/name maxExemptions',
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/type java.lang.Integer',
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/value 10',
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/override true',
+        'rm Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/description',
+        ]
+      )
+    }
+  end
+  context 'Set description' do
+    let :params do
+      {
+        :catalina_base => '/opt/apache-tomcat/foo',
+        :type          => 'java.lang.Integer',
+        :value         => '10',
+        :description   => 'foo bar',
+      }
+    end
+    it { is_expected.to contain_augeas('context-/opt/apache-tomcat/foo-environment-maxExemptions').with(
+      'lens'    => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/foo/conf/context.xml',
+      'changes' => [
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/name maxExemptions',
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/type java.lang.Integer',
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/value 10',
+        'rm Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/override',
+        'set Context/Environment[#attribute/name=\'maxExemptions\']/#attribute/description \'foo bar\'',
+        ]
+      )
+    }
+  end
+  context 'Failing Tests' do
+    context 'Bad ensure' do
+      let :params do
+        {
+          :ensure        => 'foobar',
+          :catalina_base => '/opt/apache-tomcat/foo',
+        }
+      end
+      it do
+        expect {
+          catalogue
+        }.to raise_error(Puppet::Error, /does not match/)
+      end
+    end
+    context 'Empty catalina_base' do
+      let :params do
+        {
+          :catalina_base => '',
+        }
+      end
+      it do
+        expect {
+          catalogue
+        }.to raise_error(Puppet::Error, /is not an absolute path/)
+      end
+    end
+    context 'No type' do
+      let :params do
+        {
+          :catalina_base => '/opt/apache-tomcat/foo',
+          :value         => '10',
+        }
+      end
+      it do
+        expect {
+          catalogue
+        }.to raise_error(Puppet::Error, /\$type must be specified/)
+      end
+    end
+    context 'No value' do
+      let :params do
+        {
+          :catalina_base => '/opt/apache-tomcat/foo',
+          :type          => 'java.lang.Integer',
+        }
+      end
+      it do
+        expect {
+          catalogue
+        }.to raise_error(Puppet::Error, /\$value must be specified/)
+      end
+    end
+    context 'Bad override' do
+      let :params do
+        {
+          :catalina_base => '/opt/apache-tomcat/foo',
+          :type          => 'java.lang.Integer',
+          :value         => '10',
+          :override      => 'foobar',
+        }
+      end
+      it do
+        expect {
+          catalogue
+        }.to raise_error(Puppet::Error, /\$override must be true or false/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a new defined resource for managing environment entries in the context.xml in catalina_base/conf.
Supports to add, change or delete an entry. Supports all parameters according to the documentation of Tomcat 8.0.

Can someone please review this PR? Thanks!