### PR TITLE
Feature service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ Specifies a server.xml file to manage. Valid options: a string containing an abs
 
 #####`service_name`
 
-Specifies the name of the Service to be created. Tomcats default service name is `Catalina`. Defaults to `$name`.
+Specifies the name of the Service to be created. Tomcats default service name is 'Catalina'. Defaults to '$name'.
 
 #####`catalina_base`
 
@@ -598,7 +598,7 @@ Specifies the Java class name of a server implementation to use. Maps to the [cl
 
 #####`class_name_ensure`
 
-Specifies whether the [className XML attribute](http://tomcat.apache.org/tomcat-8.0-doc/config/service.html#Common_Attributes) should exist in the configuration file. Valid options: 'true', 'false', 'present', and 'absent'. Default: 'present'.
+Specifies whether the optional [className XML attribute](http://tomcat.apache.org/tomcat-8.0-doc/config/service.html#Common_Attributes) should exist in the configuration file. Valid options: 'true', 'false', 'present', and 'absent'. Default: 'absent'.
 
 #####`server_config`
 

--- a/README.md
+++ b/README.md
@@ -584,6 +584,10 @@ Specifies a server.xml file to manage. Valid options: a string containing an abs
 
 ####tomcat::config::server::service
 
+#####`service_name`
+
+Specifies the name of the Service to be created. Tomcats default service name is `Catalina`. Defaults to `$name`.
+
 #####`catalina_base`
 
 Specifies the base directory of the Tomcat installation. Valid options: a string containing an absolute path. Default: $::tomcat::catalina_home.

--- a/manifests/config/server/service.pp
+++ b/manifests/config/server/service.pp
@@ -43,6 +43,8 @@ define tomcat::config::server::service (
       $_class_name = "rm Server/Service[#attribute/name='${name}']/#attribute/className"
     } elsif $class_name {
       $_class_name = "set Server/Service[#attribute/name='${name}']/#attribute/className ${class_name}"
+    } else {
+      $_class_name = undef
     }
     $_service = "set Server/Service[#attribute/name='${name}']/#attribute/name ${name}"
     $changes = delete_undef_values([$_service, $_class_name])

--- a/manifests/config/server/service.pp
+++ b/manifests/config/server/service.pp
@@ -4,6 +4,8 @@
 # $CATALINA_BASE/conf/server.xml
 #
 # Parameters:
+# - $service_name is the name of the Service to be created.
+#   Defaults to `$name`.
 # - $catalina_base is the root of the Tomcat installation.
 # - $class_name is the optional className attribute
 # - $class_name_ensure specifies whether you are trying to set or remove the
@@ -13,6 +15,7 @@
 #   service element. Valid values are 'true', 'false', 'present', or 'absent'.
 #   Defaults to 'present'.
 define tomcat::config::server::service (
+  $service_name      = $name,
   $catalina_base     = undef,
   $class_name        = undef,
   $class_name_ensure = 'present',
@@ -27,6 +30,7 @@ define tomcat::config::server::service (
     fail('Server configurations require Augeas >= 1.0.0')
   }
 
+  validate_string($service_name)
   validate_re($service_ensure, '^(present|absent|true|false)$')
   validate_re($class_name_ensure, '^(present|absent|true|false)$')
 
@@ -37,21 +41,21 @@ define tomcat::config::server::service (
   }
 
   if $service_ensure =~ /^(absent|false)$/ {
-    $changes = "rm Server/Service[#attribute/name='${name}']"
+    $changes = "rm Server/Service[#attribute/name='${service_name}']"
   } else {
     if $class_name_ensure =~ /^(absent|false)$/ {
-      $_class_name = "rm Server/Service[#attribute/name='${name}']/#attribute/className"
+      $_class_name = "rm Server/Service[#attribute/name='${service_name}']/#attribute/className"
     } elsif $class_name {
-      $_class_name = "set Server/Service[#attribute/name='${name}']/#attribute/className ${class_name}"
+      $_class_name = "set Server/Service[#attribute/name='${service_name}']/#attribute/className ${class_name}"
     } else {
       $_class_name = undef
     }
-    $_service = "set Server/Service[#attribute/name='${name}']/#attribute/name ${name}"
+    $_service = "set Server/Service[#attribute/name='${service_name}']/#attribute/name ${service_name}"
     $changes = delete_undef_values([$_service, $_class_name])
   }
 
   if ! empty($changes) {
-    augeas { "server-${_catalina_base}-service-${name}":
+    augeas { "server-${_catalina_base}-service-${service_name}":
       lens    => 'Xml.lns',
       incl    => $_server_config,
       changes => $changes,

--- a/manifests/config/server/service.pp
+++ b/manifests/config/server/service.pp
@@ -10,7 +10,7 @@
 # - $class_name is the optional className attribute
 # - $class_name_ensure specifies whether you are trying to set or remove the
 #   className attribute. Valid values are 'true', 'false', 'present', or
-#   'absent'. Defaults to 'present'.
+#   'absent'. Defaults to 'absent'.
 # - $service_ensure specifies whether you are trying to add or remove the
 #   service element. Valid values are 'true', 'false', 'present', or 'absent'.
 #   Defaults to 'present'.
@@ -18,7 +18,7 @@ define tomcat::config::server::service (
   $service_name      = $name,
   $catalina_base     = undef,
   $class_name        = undef,
-  $class_name_ensure = 'present',
+  $class_name_ensure = 'absent',
   $service_ensure    = 'present',
   $server_config     = undef,
 ) {
@@ -43,12 +43,13 @@ define tomcat::config::server::service (
   if $service_ensure =~ /^(absent|false)$/ {
     $changes = "rm Server/Service[#attribute/name='${service_name}']"
   } else {
-    if $class_name_ensure =~ /^(absent|false)$/ {
-      $_class_name = "rm Server/Service[#attribute/name='${service_name}']/#attribute/className"
-    } elsif $class_name {
+    if $class_name_ensure =~ /^(present|true)$/ {
+      if empty($class_name) {
+        fail('$class_name must be specified when $class_name_ensure is set to true or present')
+      }
       $_class_name = "set Server/Service[#attribute/name='${service_name}']/#attribute/className ${class_name}"
     } else {
-      $_class_name = undef
+      $_class_name = "rm Server/Service[#attribute/name='${service_name}']/#attribute/className"
     }
     $_service = "set Server/Service[#attribute/name='${service_name}']/#attribute/name ${service_name}"
     $changes = delete_undef_values([$_service, $_class_name])

--- a/spec/defines/config/server/service_spec.rb
+++ b/spec/defines/config/server/service_spec.rb
@@ -31,6 +31,24 @@ describe 'tomcat::config::server::service', :type => :define do
       ]
     ) }
   end
+  context 'set specific service_name' do
+    let :params do
+      {
+        :service_name      => 'Foobar',
+        :catalina_base     => '/opt/apache-tomcat/test',
+        :class_name_ensure => 'false',
+        :server_config     => '/opt/apache-tomcat/server.xml',
+      }
+    end
+    it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-service-Foobar').with(
+      'lens'    => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/server.xml',
+      'changes' => [
+        'set Server/Service[#attribute/name=\'Foobar\']/#attribute/name Foobar',
+        'rm Server/Service[#attribute/name=\'Foobar\']/#attribute/className',
+      ]
+    ) }
+  end
   context 'remove classname' do
     let :params do
       {
@@ -59,6 +77,22 @@ describe 'tomcat::config::server::service', :type => :define do
       'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
       'changes' => [
         'rm Server/Service[#attribute/name=\'Catalina\']',
+      ]
+    ) }
+  end
+  context 'remove service with specific service_name' do
+    let :params do
+      {
+        :service_name   => 'Foobar',
+        :catalina_base  => '/opt/apache-tomcat/test',
+        :service_ensure => 'false',
+      }
+    end
+    it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-service-Foobar').with(
+      'lens'    => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
+      'changes' => [
+        'rm Server/Service[#attribute/name=\'Foobar\']',
       ]
     ) }
   end

--- a/spec/defines/config/server/service_spec.rb
+++ b/spec/defines/config/server/service_spec.rb
@@ -107,6 +107,7 @@ describe 'tomcat::config::server::service', :type => :define do
       'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
       'changes' => [
         'set Server/Service[#attribute/name=\'Catalina\']/#attribute/name Catalina',
+        'rm Server/Service[#attribute/name=\'Catalina\']/#attribute/className',
       ]
     ) }
   end
@@ -133,6 +134,18 @@ describe 'tomcat::config::server::service', :type => :define do
         expect {
           catalogue
         }.to raise_error(Puppet::Error, /does not match/)
+      end
+    end
+    context 'no class_name when class_name_ensure specified' do
+      let :params do
+        {
+          :class_name_ensure => 'present'
+        }
+      end
+      it do
+        expect {
+          catalogue
+        }.to raise_error(Puppet::Error, /must be specified/)
       end
     end
     context 'old augeas' do

--- a/spec/defines/config/server/service_spec.rb
+++ b/spec/defines/config/server/service_spec.rb
@@ -21,16 +21,15 @@ describe 'tomcat::config::server::service', :type => :define do
         :class_name_ensure => 'true',
         :server_config     => '/opt/apache-tomcat/server.xml',
       }
-      it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-service-Catalina').with(
-        'lens'    => 'Xml.lns',
-        'incl'    => '/opt/apache-tomcat/server.xml',
-        'changes' => [
-          'set Server/Service[#attribute/name=\'Catalina\']/#attribute/name Catalina',
-          'set Server/Service[#attribute/name=\'Catalina\']/#attribute/className foo',
-        ]
-      )
-      }
     end
+    it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-service-Catalina').with(
+      'lens'    => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/server.xml',
+      'changes' => [
+        'set Server/Service[#attribute/name=\'Catalina\']/#attribute/name Catalina',
+        'set Server/Service[#attribute/name=\'Catalina\']/#attribute/className foo',
+      ]
+    ) }
   end
   context 'remove classname' do
     let :params do
@@ -38,16 +37,15 @@ describe 'tomcat::config::server::service', :type => :define do
         :catalina_base     => '/opt/apache-tomcat/test',
         :class_name_ensure => 'false',
       }
-      it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-service-Catalina').with(
-        'lens'    => 'Xml.lns',
-        'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
-        'changes' => [
-          'set Server/Service[#attribute/name=\'Catalina\']/#attribute/name Catalina',
-          'rm Server/Service[#attribute/name=\'Catalina\']/#attribute/className',
-        ]
-      )
-      }
     end
+    it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-service-Catalina').with(
+      'lens'    => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
+      'changes' => [
+        'set Server/Service[#attribute/name=\'Catalina\']/#attribute/name Catalina',
+        'rm Server/Service[#attribute/name=\'Catalina\']/#attribute/className',
+      ]
+    ) }
   end
   context 'remove service' do
     let :params do
@@ -55,23 +53,28 @@ describe 'tomcat::config::server::service', :type => :define do
         :catalina_base  => '/opt/apache-tomcat/test',
         :service_ensure => 'false',
       }
-      it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-service-Catalina').with(
-        'lens'    => 'Xml.lns',
-        'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
-        'changes' => [
-          'rm Server/Service[#attribute/name=\'Catalina\']',
-        ]
-      )
-      }
     end
+    it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-service-Catalina').with(
+      'lens'    => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
+      'changes' => [
+        'rm Server/Service[#attribute/name=\'Catalina\']',
+      ]
+    ) }
   end
   context 'no changes' do
     let :params do
       {
         :catalina_base  => '/opt/apache-tomcat/test',
       }
-      it { is_expected.to_not contain_augeas('server-/opt/apache-tomcat/test-service-Catalina') }
     end
+    it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-service-Catalina').with(
+      'lens'    => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
+      'changes' => [
+        'set Server/Service[#attribute/name=\'Catalina\']/#attribute/name Catalina',
+      ]
+    ) }
   end
   describe 'failing tests' do
     context 'bad service_ensure' do


### PR DESCRIPTION
Changes for the define tomcat::config::server::service: add a param for service_name. The first commits include a few fixes in the spec files.
The optional className in Tomcats Service element is now absent by default.

I hope it's okay to have multiple commits for all changes in one PR. 