### PR TITLE
Feature: Add the ability to configure manager elements in context.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Puppet removes any existing Connectors or Realms and leaves only the ones you've
 * `tomcat::config::server::tomcat_users`: Configures user and role elements for [UserDatabaseRealm] (http://tomcat.apache.org/tomcat-8.0-doc/realm-howto.html#UserDatabaseRealm) or [MemoryRealm] (http://tomcat.apache.org/tomcat-8.0-doc/realm-howto.html#MemoryRealm) in `$CATALINA_BASE/conf/tomcat-users.xml` or any other specified file.
 * `tomcat::config::server::valve`: Configures a [Valve](http://tomcat.apache.org/tomcat-8.0-doc/config/valve.html) element in `$CATALINA_BASE/conf/server.xml`.
 * `tomcat::config::context`: Configures a [Context](http://tomcat.apache.org/tomcat-8.0-doc/config/context.html) element in $CATALINA_BASE/conf/context.xml.
+* `tomcat::config::context::manager`: Configures a [Manager](https://tomcat.apache.org/tomcat-8.0-doc/config/manager.html) element in $CATALINA_BASE/conf/context.xml.
 * `tomcat::config::context::resource`: Configures a [Resource](http://tomcat.apache.org/tomcat-8.0-doc/config/context.html#Resource_Definitions) element in $CATALINA_BASE/conf/context.xml.
 * `tomcat::config::context::resourcelink`: Configures a [ResourceLink](http://tomcat.apache.org/tomcat-8.0-doc/config/context.html#Resource_Links) element in $CATALINA_BASE/conf/context.xml.
 * `tomcat::install`: Installs a Tomcat instance.
@@ -678,6 +679,30 @@ Specifies a configuration Context element in `${catalina_base}/conf/context.xml`
 ##### `catalina_base`
 
 Specifies the root of the Tomcat installation.
+
+#### tomcat::config::context::manager
+Specifies a Manager element in the designated xml configuration.
+
+##### `ensure`
+
+specifies whether you are trying to add or remove the Manager element. Valid values are 'true', 'false', 'present', and 'absent'. Defaults to 'present'
+
+##### `catalina_base`
+
+Specifies the root of the Tomcat installation. Default: `$tomcat::catalina_home`
+
+##### `manager_classname`
+
+The name of the Manager to be created. Default: `$name`
+
+##### `additional_attributes`
+
+Specifies any additional attributes to add to the Manager. Should be a hash of the format 'attribute' => 'value'. This parameter is optional.
+
+##### `attributes_to_remove`
+
+Specifies any attributes to remove from the Manager. Should be a hash of the format 'attribute' => 'value'. This parameter is optional.
+
 
 #### tomcat::config::context::resource
 Specifies Resource elements in `${catalina_base}/conf/context.xml`

--- a/manifests/config/context/manager.pp
+++ b/manifests/config/context/manager.pp
@@ -1,0 +1,69 @@
+# Definition: tomcat::config::context::manager
+#
+# Configure Manager elements in $CATALINA_BASE/conf/context.xml
+#
+# Parameters:
+# - $catalina_base is the base directory for the Tomcat installation.
+# - $ensure specifies whether you are trying to add or remove the
+#   Manager element. Valid values are 'true', 'false', 'present', and
+#   'absent'. Defaults to 'present'.
+# - $manager_name is the name of the Manager to be created, relative to
+#   the java:comp/env context.
+# - $type is the fully qualified Java class name expected by the web application
+#   when it performs a lookup for this manager
+# - An optional hash of $additional_attributes to add to the Manager. Should
+#   be of the format 'attribute' => 'value'.
+# - An optional array of $attributes_to_remove from the Manager.
+define tomcat::config::context::manager (
+  $ensure                = 'present',
+  $catalina_base         = $::tomcat::catalina_home,
+  $manager_classname     = $name,
+  $additional_attributes = {},
+  $attributes_to_remove  = [],
+) {
+  if versioncmp($::augeasversion, '1.0.0') < 0 {
+    fail('Server configurations require Augeas >= 1.0.0')
+  }
+
+  validate_re($ensure, '^(present|absent|true|false)$')
+
+  if $manager_classname {
+    $_manager_classname = $manager_classname
+  } else {
+    $_manager_classname = $name
+  }
+
+  $base_path = "Context/Manager[#attribute/className='${_manager_classname}']"
+
+  if $ensure =~ /^(absent|false)$/ {
+    $changes = "rm ${base_path}"
+  } else {
+    $set_name = "set ${base_path}/#attribute/className '${_manager_classname}'"
+
+    if ! empty($additional_attributes) {
+      $set_additional_attributes =
+        suffix(prefix(join_keys_to_values($additional_attributes, " '"),
+          "set ${base_path}/#attribute/"), "'")
+    } else {
+      $set_additional_attributes = undef
+    }
+    if ! empty(any2array($attributes_to_remove)) {
+      $rm_attributes_to_remove =
+        prefix(any2array($attributes_to_remove), "rm ${base_path}/#attribute/")
+    } else {
+      $rm_attributes_to_remove = undef
+    }
+
+    $changes = delete_undef_values(flatten([
+      $set_name,
+      $set_additional_attributes,
+      $rm_attributes_to_remove,
+    ]))
+  }
+
+  augeas { "context-${catalina_base}-manager-${name}":
+    lens    => 'Xml.lns',
+    incl    => "${catalina_base}/conf/context.xml",
+    changes => $changes,
+  }
+}

--- a/spec/defines/config/context/manager_spec.rb
+++ b/spec/defines/config/context/manager_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe 'tomcat::config::context::manager', :type => :define do
+  let :pre_condition do
+    'class {"tomcat": }'
+  end
+  let :facts do
+    {
+      :osfamily => 'Debian',
+      :augeasversion => '1.0.0'
+    }
+  end
+  let :title do
+    'memcached'
+  end
+  context 'Add Manager' do
+    let :params do
+      {
+        :catalina_base          => '/opt/apache-tomcat/test',
+        :manager_classname      => 'memcached',
+        :additional_attributes  => {
+          'barfoo'  => 'foofoo',
+          'fizz'    => 'buzz',
+        },
+        :attributes_to_remove  => [
+          'foobar',
+        ],
+      }
+    end
+    it { is_expected.to contain_augeas('context-/opt/apache-tomcat/test-manager-memcached').with(
+      'lens' => 'Xml.lns',
+      'incl' => '/opt/apache-tomcat/test/conf/context.xml',
+      'changes' => [
+        'set Context/Manager[#attribute/className=\'memcached\']/#attribute/className \'memcached\'',
+        'set Context/Manager[#attribute/className=\'memcached\']/#attribute/barfoo \'foofoo\'',
+        'set Context/Manager[#attribute/className=\'memcached\']/#attribute/fizz \'buzz\'',
+        'rm Context/Manager[#attribute/className=\'memcached\']/#attribute/foobar',
+        ]
+      )
+    }
+  end
+  context 'Remove Manager' do
+    let :params do
+      {
+        :catalina_base => '/opt/apache-tomcat/test',
+        :ensure        => 'absent',
+      }
+    end
+    it { is_expected.to contain_augeas('context-/opt/apache-tomcat/test-manager-memcached').with(
+      'lens' => 'Xml.lns',
+      'incl' => '/opt/apache-tomcat/test/conf/context.xml',
+      'changes' => [
+        'rm Context/Manager[#attribute/className=\'memcached\']',
+        ]
+      )
+    }
+  end
+end


### PR DESCRIPTION
Adds a new defined type (tomcat::config::context::manager) which enables users to configure Manager elements in context.xml (https://tomcat.apache.org/tomcat-7.0-doc/config/manager.html). Supports adding or removing params as the users wishes. 