### PR TITLE
fix MODULES-3353 by making sure the Resource name is defined first

### DIFF
--- a/manifests/config/server/globalnamingresource.pp
+++ b/manifests/config/server/globalnamingresource.pp
@@ -53,6 +53,13 @@ define tomcat::config::server::globalnamingresource (
     ]))
   }
 
+  augeas { "server-${catalina_base}-globalresource-${name}-definition":
+    lens    => 'Xml.lns',
+    incl    => $_server_config,
+    changes => "set ${base_path}/#attribute/name '${name}'",
+    before  => Augeas["server-${catalina_base}-globalresource-${name}"],
+  }
+
   augeas { "server-${catalina_base}-globalresource-${name}":
     lens    => 'Xml.lns',
     incl    => $_server_config,


### PR DESCRIPTION
The code in 1.5.0 doesn't work for defining new globalnamingresources, only for modifying existing ones.

With these changes, puppetlabs-tomcat will now be able to define new Resources as well.