### PR TITLE
changed user and group for the extract resource

### DIFF
--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -57,8 +57,8 @@ define tomcat::install::source (
     target  => $catalina_home,
     require => Staging::File[$filename],
     unless  => "test \"\$(ls -A ${catalina_home})\"",
-    user    => $::tomcat::user,
-    group   => $::tomcat::group,
+    user    => $user,
+    group   => $group,
     strip   => $_strip,
   }
 }


### PR DESCRIPTION
$catalina_home gets created with $user:$group as the owner. But, extraction was happening with the default/hiera user and group ($::tomcat::group and $::tomcat::user). If these are not the same or can't access to each other's files, extraction will fail with permission issues.