### PR TITLE
add service_name to tomcat::config::server::service

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,10 @@ Specifies a server.xml file to manage. Valid options: a string containing an abs
 
 ####tomcat::config::server::service
 
+#####`service_name`
+
+Specifies the name of the Service to be created. Tomcats default service name is 'Catalina'. Defaults to '$name'.
+
 #####`catalina_base`
 
 Specifies the base directory of the Tomcat installation. Valid options: a string containing an absolute path. Default: $::tomcat::catalina_home.
@@ -596,7 +600,7 @@ Specifies the Java class name of a server implementation to use. Maps to the [cl
 
 #####`class_name_ensure`
 
-Specifies whether the [className XML attribute](http://tomcat.apache.org/tomcat-8.0-doc/config/service.html#Common_Attributes) should exist in the configuration file. Valid options: 'true', 'false', 'present', and 'absent'. Default: 'present'.
+Specifies whether the optional [className XML attribute](http://tomcat.apache.org/tomcat-8.0-doc/config/service.html#Common_Attributes) should exist in the configuration file. Valid options: 'true', 'false', 'present', and 'absent'. Default: 'absent'.
 
 #####`server_config`
 

--- a/manifests/config/server/service.pp
+++ b/manifests/config/server/service.pp
@@ -4,18 +4,21 @@
 # $CATALINA_BASE/conf/server.xml
 #
 # Parameters:
+# - $service_name is the name of the Service to be created.
+#   Defaults to `$name`.
 # - $catalina_base is the root of the Tomcat installation.
 # - $class_name is the optional className attribute
 # - $class_name_ensure specifies whether you are trying to set or remove the
 #   className attribute. Valid values are 'true', 'false', 'present', or
-#   'absent'. Defaults to 'present'.
+#   'absent'. Defaults to 'absent'.
 # - $service_ensure specifies whether you are trying to add or remove the
 #   service element. Valid values are 'true', 'false', 'present', or 'absent'.
 #   Defaults to 'present'.
 define tomcat::config::server::service (
+  $service_name      = $name,
   $catalina_base     = undef,
   $class_name        = undef,
-  $class_name_ensure = 'present',
+  $class_name_ensure = 'absent',
   $service_ensure    = 'present',
   $server_config     = undef,
 ) {
@@ -27,6 +30,7 @@ define tomcat::config::server::service (
     fail('Server configurations require Augeas >= 1.0.0')
   }
 
+  validate_string($service_name)
   validate_re($service_ensure, '^(present|absent|true|false)$')
   validate_re($class_name_ensure, '^(present|absent|true|false)$')
 
@@ -37,19 +41,22 @@ define tomcat::config::server::service (
   }
 
   if $service_ensure =~ /^(absent|false)$/ {
-    $changes = "rm Server/Service[#attribute/name='${name}']"
+    $changes = "rm Server/Service[#attribute/name='${service_name}']"
   } else {
-    if $class_name_ensure =~ /^(absent|false)$/ {
-      $_class_name = "rm Server/Service[#attribute/name='${name}']/#attribute/className"
-    } elsif $class_name {
-      $_class_name = "set Server/Service[#attribute/name='${name}']/#attribute/className ${class_name}"
+    if $class_name_ensure =~ /^(present|true)$/ {
+      if empty($class_name) {
+        fail('$class_name must be specified when $class_name_ensure is set to true or present')
+      }
+      $_class_name = "set Server/Service[#attribute/name='${service_name}']/#attribute/className ${class_name}"
+    } else {
+      $_class_name = "rm Server/Service[#attribute/name='${service_name}']/#attribute/className"
     }
-    $_service = "set Server/Service[#attribute/name='${name}']/#attribute/name ${name}"
+    $_service = "set Server/Service[#attribute/name='${service_name}']/#attribute/name ${service_name}"
     $changes = delete_undef_values([$_service, $_class_name])
   }
 
   if ! empty($changes) {
-    augeas { "server-${_catalina_base}-service-${name}":
+    augeas { "server-${_catalina_base}-service-${service_name}":
       lens    => 'Xml.lns',
       incl    => $_server_config,
       changes => $changes,


### PR DESCRIPTION
This PR adds the param service_name to tomcat::config::server::service. This allows to use the define to manage multiple services with the same name for different Tomcat instances. Having unique resource names but specifing the same service_name. The optional className in Tomcats Service element is now absent by default.
I did squash the commits as I was asked for in PR #139. Thanks for merging!
