### PR TITLE
MODULES-3436 export prefix in sysconfig/tomcat does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Puppet removes any existing Connectors or Realms and leaves only the ones you've
 * `tomcat::config::server::tomcat_users`: Configures user and role elements for [UserDatabaseRealm] (http://tomcat.apache.org/tomcat-8.0-doc/realm-howto.html#UserDatabaseRealm) or [MemoryRealm] (http://tomcat.apache.org/tomcat-8.0-doc/realm-howto.html#MemoryRealm) in `$CATALINA_BASE/conf/tomcat-users.xml` or any other specified file.
 * `tomcat::config::server::valve`: Configures a [Valve](http://tomcat.apache.org/tomcat-8.0-doc/config/valve.html) element in `$CATALINA_BASE/conf/server.xml`.
 * `tomcat::config::context`: Configures a [Context](http://tomcat.apache.org/tomcat-8.0-doc/config/context.html) element in $CATALINA_BASE/conf/context.xml.
+* `tomcat::config::context::manager`: Configures a [Manager](https://tomcat.apache.org/tomcat-8.0-doc/config/manager.html) element in $CATALINA_BASE/conf/context.xml.
 * `tomcat::config::context::environment`: Configures a [Environment](http://tomcat.apache.org/tomcat-8.0-doc/config/context.html#Environment_Entries) element in $CATALINA_BASE/conf/context.xml.
 * `tomcat::config::context::resource`: Configures a [Resource](http://tomcat.apache.org/tomcat-8.0-doc/config/context.html#Resource_Definitions) element in $CATALINA_BASE/conf/context.xml.
 * `tomcat::config::context::resourcelink`: Configures a [ResourceLink](http://tomcat.apache.org/tomcat-8.0-doc/config/context.html#Resource_Links) element in $CATALINA_BASE/conf/context.xml.
@@ -681,6 +682,29 @@ Specifies a configuration Context element in `${catalina_base}/conf/context.xml`
 ##### `catalina_base`
 
 Specifies the root of the Tomcat installation.
+
+#### tomcat::config::context::manager
+Specifies a Manager element in the designated xml configuration.
+
+##### `ensure`
+
+specifies whether you are trying to add or remove the Manager element. Valid values are 'true', 'false', 'present', and 'absent'. Defaults to 'present'
+
+##### `catalina_base`
+
+Specifies the root of the Tomcat installation. Default: `$tomcat::catalina_home`
+
+##### `manager_classname`
+
+The name of the Manager to be created. Default: `$name`
+
+##### `additional_attributes`
+
+Specifies any additional attributes to add to the Manager. Should be a hash of the format 'attribute' => 'value'. This parameter is optional.
+
+##### `attributes_to_remove`
+
+Specifies any attributes to remove from the Manager. Should be a hash of the format 'attribute' => 'value'. This parameter is optional.
 
 #### tomcat::config::context::environment
 

--- a/README.md
+++ b/README.md
@@ -975,6 +975,10 @@ Specifies a character to include before and after the specified value. Valid opt
 
 *Required.* Provides the value(s) of the managed parameter. Valid options: a string or an array. If passing an array, separate values with a single space.
 
+#####`doexport`
+
+Specifies if you want to append export to the entry. Valid Options: true or false Default: (true).
+
 ####tomcat::war
 
 #####`app_base`

--- a/manifests/config/context/manager.pp
+++ b/manifests/config/context/manager.pp
@@ -1,0 +1,69 @@
+# Definition: tomcat::config::context::manager
+#
+# Configure Manager elements in $CATALINA_BASE/conf/context.xml
+#
+# Parameters:
+# - $catalina_base is the base directory for the Tomcat installation.
+# - $ensure specifies whether you are trying to add or remove the
+#   Manager element. Valid values are 'true', 'false', 'present', and
+#   'absent'. Defaults to 'present'.
+# - $manager_name is the name of the Manager to be created, relative to
+#   the java:comp/env context.
+# - $type is the fully qualified Java class name expected by the web application
+#   when it performs a lookup for this manager
+# - An optional hash of $additional_attributes to add to the Manager. Should
+#   be of the format 'attribute' => 'value'.
+# - An optional array of $attributes_to_remove from the Manager.
+define tomcat::config::context::manager (
+  $ensure                = 'present',
+  $catalina_base         = $::tomcat::catalina_home,
+  $manager_classname     = $name,
+  $additional_attributes = {},
+  $attributes_to_remove  = [],
+) {
+  if versioncmp($::augeasversion, '1.0.0') < 0 {
+    fail('Server configurations require Augeas >= 1.0.0')
+  }
+
+  validate_re($ensure, '^(present|absent|true|false)$')
+
+  if $manager_classname {
+    $_manager_classname = $manager_classname
+  } else {
+    $_manager_classname = $name
+  }
+
+  $base_path = "Context/Manager[#attribute/className='${_manager_classname}']"
+
+  if $ensure =~ /^(absent|false)$/ {
+    $changes = "rm ${base_path}"
+  } else {
+    $set_name = "set ${base_path}/#attribute/className '${_manager_classname}'"
+
+    if ! empty($additional_attributes) {
+      $set_additional_attributes =
+        suffix(prefix(join_keys_to_values($additional_attributes, " '"),
+          "set ${base_path}/#attribute/"), "'")
+    } else {
+      $set_additional_attributes = undef
+    }
+    if ! empty(any2array($attributes_to_remove)) {
+      $rm_attributes_to_remove =
+        prefix(any2array($attributes_to_remove), "rm ${base_path}/#attribute/")
+    } else {
+      $rm_attributes_to_remove = undef
+    }
+
+    $changes = delete_undef_values(flatten([
+      $set_name,
+      $set_additional_attributes,
+      $rm_attributes_to_remove,
+    ]))
+  }
+
+  augeas { "context-${catalina_base}-manager-${name}":
+    lens    => 'Xml.lns',
+    incl    => "${catalina_base}/conf/context.xml",
+    changes => $changes,
+  }
+}

--- a/manifests/setenv/entry.pp
+++ b/manifests/setenv/entry.pp
@@ -9,6 +9,7 @@
 # - $param is the parameter you're setting. Defaults to $name.
 # - $quote_char is the optional character to quote the value with.
 # - $order is the optional order to the param in the file. Defaults to 10
+# - $doexport is the optional prefix befor the variable.
 # - (Deprecated) $base_path is the path to create the setenv.sh script under. Should be
 #   either $catalina_base/bin or $catalina_home/bin.
 define tomcat::setenv::entry (
@@ -20,6 +21,7 @@ define tomcat::setenv::entry (
   $quote_char    = undef,
   $order         = '10',
   $addto         = undef,
+  $doexport      = true,
   # Deprecated
   $base_path     = undef,
 ) {
@@ -54,11 +56,17 @@ define tomcat::setenv::entry (
       ensure_newline => true,
     }
   }
-
-  if $addto {
-    $_content = inline_template('export <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char %> ; export <%= @addto %>="$<%= @addto %> $<%= @param %>"')
+  
+  if $doexport {
+    $_doexport = 'export'
   } else {
-    $_content = inline_template('export <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char %>')
+    $_doexport = ''
+  }
+  
+  if $addto {
+    $_content = inline_template('<%= @_doexport %> <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char %> ; <%= @_doexport %> <%= @addto %>="$<%= @addto %> $<%= @param %>"')
+  } else {
+    $_content = inline_template('<%= @_doexport %> <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char %>')
   }
   concat::fragment { "setenv-${name}":
     ensure  => $ensure,

--- a/spec/defines/config/context/manager_spec.rb
+++ b/spec/defines/config/context/manager_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe 'tomcat::config::context::manager', :type => :define do
+  let :pre_condition do
+    'class {"tomcat": }'
+  end
+  let :facts do
+    {
+      :osfamily => 'Debian',
+      :augeasversion => '1.0.0'
+    }
+  end
+  let :title do
+    'memcached'
+  end
+  context 'Add Manager' do
+    let :params do
+      {
+        :catalina_base          => '/opt/apache-tomcat/test',
+        :manager_classname      => 'memcached',
+        :additional_attributes  => {
+          'barfoo'  => 'foofoo',
+          'fizz'    => 'buzz',
+        },
+        :attributes_to_remove  => [
+          'foobar',
+        ],
+      }
+    end
+    it { is_expected.to contain_augeas('context-/opt/apache-tomcat/test-manager-memcached').with(
+      'lens' => 'Xml.lns',
+      'incl' => '/opt/apache-tomcat/test/conf/context.xml',
+      'changes' => [
+        'set Context/Manager[#attribute/className=\'memcached\']/#attribute/className \'memcached\'',
+        'set Context/Manager[#attribute/className=\'memcached\']/#attribute/barfoo \'foofoo\'',
+        'set Context/Manager[#attribute/className=\'memcached\']/#attribute/fizz \'buzz\'',
+        'rm Context/Manager[#attribute/className=\'memcached\']/#attribute/foobar',
+        ]
+      )
+    }
+  end
+  context 'Remove Manager' do
+    let :params do
+      {
+        :catalina_base => '/opt/apache-tomcat/test',
+        :ensure        => 'absent',
+      }
+    end
+    it { is_expected.to contain_augeas('context-/opt/apache-tomcat/test-manager-memcached').with(
+      'lens' => 'Xml.lns',
+      'incl' => '/opt/apache-tomcat/test/conf/context.xml',
+      'changes' => [
+        'rm Context/Manager[#attribute/className=\'memcached\']',
+        ]
+      )
+    }
+  end
+end


### PR DESCRIPTION
Prefixing export to /etc/sysconfig/tomcat values does not work.

This change will allow user to select weather they want to prefix export or not.