### PR TITLE
Update nanliu-staging to puppet-staging since it has been absorbed

### DIFF
--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -7,7 +7,7 @@
 # - The $source_url to install from.
 # - $source_strip_first_dir is a boolean specifying whether or not to strip
 #   the first directory when unpacking the source tarball. Defaults to true
-#   when installing from source on non-Solaris systems. Requires nanliu/staging
+#   when installing from source on non-Solaris systems. Requires puppet/staging
 #   > 0.4.0
 define tomcat::install::source (
   $catalina_home,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -14,7 +14,7 @@
 # - The $source_url to install from. Required if $install_from_source is true.
 # - $source_strip_first_dir is a boolean specifying whether or not to strip
 #   the first directory when unpacking the source tarball. Defaults to true
-#   when installing from source. Requires nanliu/staging > 0.4.0
+#   when installing from source. Requires puppet/staging > 0.4.0
 # - $package_ensure when installing from package, what the ensure should be set
 #   to in the package resource.
 # - $package_name is the name of the package you want to install. Required if

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 < 3.0.0"},
-    {"name":"nanliu/staging","version_requirement":">= 0.4.1 < 2.0.0"}
+    {"name":"puppet/staging","version_requirement":">= 0.4.1 < 2.0.0"}
   ],
   "operatingsystem_support": [
     {

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -57,7 +57,7 @@ RSpec.configure do |c|
       on host, puppet('module','install','puppetlabs-concat'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module','install','puppetlabs-java'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module','install','puppetlabs-gcc'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module','install','nanliu-staging'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module','install','puppet-staging'), { :acceptable_exit_codes => [0,1] }
     end
   end
 end


### PR DESCRIPTION
According to https://forge.puppet.com/puppet/staging/changelog the staging module is now being handled by Puppetlabs themselves. 

To avoid duplicate modules conflicting with other modules, move to the new standard