### PR TITLE
Add owner/group to tomcat_users.pp

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,9 +629,17 @@ Determines whether the specified XML element should exist in the configuration f
 
 Specifies the configuration file to manage. Valid options: a string containing a fully-qualified path. Default: '$CATALINA_BASE/conf/tomcat-users.xml'.
 
+#####`group`
+
+Specifies the group of the configuration file. Default: `$::tomcat::group`
+
 #####`manage_file`
 
 Specifies whether to create the specified configuration file if it doesn't exist. Uses Puppet's native [`file` resource type](https://docs.puppetlabs.com/references/latest/type.html#file) with default parameters. Valid options: 'true' and 'false'. Default: 'true'.
+
+#####`owner`
+
+Specifies the owner of the configuration file. Default: `$::tomcat::user`
 
 #####`password`
 

--- a/manifests/config/server/tomcat_users.pp
+++ b/manifests/config/server/tomcat_users.pp
@@ -16,6 +16,8 @@
 #   Defaults to $CATALINA_BASE/conf/tomcat-users.xml.
 # - Set $manage_file to true for managing the file. It sets file permission,
 #   owner, group and create a basic tomcat-users XML if file does not exist yet.
+# - $owner specifies the owner of the file if $manage_file is true. Default: $tomcat::user
+# - $group specifies the group of the file if $manage_file is true. Default: $tomcat::group
 # - $password specifies the password for a user ($element = 'user').
 # - $roles specifies the roles for a user ($element = 'user').
 #
@@ -26,6 +28,8 @@ define tomcat::config::server::tomcat_users (
   $ensure        = present,
   $file          = undef,
   $manage_file   = true,
+  $owner         = undef,
+  $group         = undef,
   $password      = undef,
   $roles         = [],
 ) {
@@ -33,6 +37,9 @@ define tomcat::config::server::tomcat_users (
   if versioncmp($::augeasversion, '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
+
+  $_owner = pick($owner, $::tomcat::user)
+  $_group = pick($group, $::tomcat::group)
 
   validate_re($element, '^(user|role)$')
   validate_re($ensure, '^(present|absent|true|false)$')
@@ -67,8 +74,8 @@ define tomcat::config::server::tomcat_users (
       path    => $_file,
       replace => false,
       content => '<?xml version=\'1.0\' encoding=\'utf-8\'?><tomcat-users></tomcat-users>',
-      owner   => $::tomcat::user,
-      group   => $::tomcat::group,
+      owner   => $_owner,
+      group   => $_group,
       mode    => '0640',
     })
   }


### PR DESCRIPTION
When multiple tomcat instances are used under different users, then creating users with tomcat::config::server::tomcat_users will result in files with invalid owner data.
Therefore it should be allowed to pass along owner information for when the file is managed.