### PR TITLE
(MODULES-3713) Allow unmanaged catalina_home

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ Determines whether defines should default to creating the specified group, if it
 
 Determines whether defines should default to creating the specified user, if it doesn't exist. Uses Puppet's native [`user` resource type](https://docs.puppetlabs.com/references/latest/type.html#user) with default parameters. Valid options: 'true' and 'false'. Default: 'true'.
 
+#####`manage_catalina_home`
+
+Determines whether defines should default to creating the specified catalina_home directory, if it doesn't exist.  Valid options: 'true' and 'false'. Default: 'true'.  Note that catalina_home directory permissions must allow the tomcat user to read and write to the directory.
+
 #####`purge_connectors`
 
 Specifies whether to purge any unmanaged Connector elements that match defined protocol but have a different port from the configuration file by default. Valid options: 'true' and 'false'. Default: 'false'.
@@ -822,7 +826,7 @@ Tomcat instances may then be created from the install using `tomcat::instance` a
 specifies the directory of the Tomcat installation from which the instance should be created. Valid options: a string containing an absolute path. Default: $::tomcat::catalina_home.
 
 ##### `install_from_source`
-Specifies whether to install from source or from a package. If set to `true` installation uses the `source_url`, `source_strip_first_dir`, `user`, `group`, `manage_user`, and `manage_group` parameters. If set to `false` installation uses the `package_ensure`, `package_name`, and `package_options` parameters.
+Specifies whether to install from source or from a package. If set to `true` installation uses the `source_url`, `source_strip_first_dir`, `user`, `group`, `manage_user`, `manage_group` and `manage_catalina_home` parameters. If set to `false` installation uses the `package_ensure`, `package_name`, and `package_options` parameters.
 
 Valid options: `true` and `false`. Default: `true`.
 
@@ -845,6 +849,9 @@ Specifies whether the user should be managed by this module or not. Default: `$:
 
 ##### `manage_group`
 Specifies whether the group should be managed by this module or not. Default: `$::tomcat::manage_group`
+
+##### `manage_catalina_home`
+Specifies whether the catalina_home directory should be managed by this module or not. Default: `$::tomcat::manage_catalina_home`
 
 ##### `package_ensure`
 Determines whether the specified package should be installed. Only valid if `install_from_source` is set to `false`. Maps to the `ensure` parameter of Puppet's native [`package` resource type](https://docs.puppetlabs.com/references/latest/type.html#package). Default: 'present'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,21 +25,26 @@
 # [*manage_group*]
 #   Boolean specifying whether or not to manage the group. Defaults to true.
 #
+# [*manage_catalina_home*]
+#   Boolean specifying whether or not to manage the catalina_home directory.  Defaults to true.
+#
 class tomcat (
-  $catalina_home       = $::tomcat::params::catalina_home,
-  $user                = $::tomcat::params::user,
-  $group               = $::tomcat::params::group,
-  $install_from_source = true,
-  $purge_connectors    = false,
-  $purge_realms        = false,
-  $manage_user         = true,
-  $manage_group        = true,
+  $catalina_home        = $::tomcat::params::catalina_home,
+  $user                 = $::tomcat::params::user,
+  $group                = $::tomcat::params::group,
+  $install_from_source  = true,
+  $purge_connectors     = false,
+  $purge_realms         = false,
+  $manage_user          = true,
+  $manage_group         = true,
+  $manage_catalina_home = true,
 ) inherits ::tomcat::params {
   validate_bool($install_from_source)
   validate_bool($purge_connectors)
   validate_bool($purge_realms)
   validate_bool($manage_user)
   validate_bool($manage_group)
+  validate_bool($manage_catalina_home)
 
   case $::osfamily {
     'windows','Solaris','Darwin': {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,6 +10,7 @@ define tomcat::install (
   $group                  = undef,
   $manage_user            = undef,
   $manage_group           = undef,
+  $manage_catalina_home   = undef,
 
   # package options
   $package_ensure         = undef,
@@ -22,6 +23,7 @@ define tomcat::install (
   $_group = pick($group, $::tomcat::group)
   $_manage_user = pick($manage_user, $::tomcat::manage_user)
   $_manage_group = pick($manage_group, $::tomcat::manage_group)
+  $_manage_catalina_home = pick($manage_catalina_home, $::tomcat::manage_catalina_home)
   validate_bool($_install_from_source, $source_strip_first_dir)
   tag(sha1($catalina_home))
 
@@ -34,6 +36,7 @@ define tomcat::install (
       group                  => $_group,
       manage_user            => $_manage_user,
       manage_group           => $_manage_group,
+      manage_catalina_home   => $_manage_catalina_home,
     }
   } else {
     tomcat::install::package { $package_name:

--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -17,6 +17,7 @@ define tomcat::install::source (
   $group,
   $manage_user,
   $manage_group,
+  $manage_catalina_home,
 ) {
   tag(sha1($catalina_home))
   include staging
@@ -42,10 +43,13 @@ define tomcat::install::source (
       ensure => present,
     })
   }
-  file { $catalina_home:
-    ensure => directory,
-    owner  => $user,
-    group  => $group,
+
+  if $manage_catalina_home {
+    ensure_resource('file', $catalina_home, {
+      ensure => directory,
+      owner  => $user,
+      group  => $group,
+    })
   }
 
   ensure_resource('staging::file',$filename, {
@@ -56,7 +60,7 @@ define tomcat::install::source (
     source  => "${::staging::path}/tomcat/${filename}",
     target  => $catalina_home,
     require => Staging::File[$filename],
-    unless  => "test \"\$(ls -A ${catalina_home})\"",
+    unless  => "test -f ${catalina_home}/NOTICE",
     user    => $user,
     group   => $group,
     strip   => $_strip,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -30,6 +30,7 @@ define tomcat::instance (
   $manage_user            = undef,
   $manage_group           = undef,
   $manage_service         = undef,
+  $manage_catalina_home   = undef,
   $java_home              = undef,
   $use_jsvc               = undef,
   $use_init               = undef,
@@ -51,6 +52,7 @@ define tomcat::instance (
   $_group = pick($group, $::tomcat::group)
   $_manage_user = pick($manage_user, $::tomcat::manage_user)
   $_manage_group = pick($manage_group, $::tomcat::manage_group)
+  $_manage_catalina_home = pick($manage_catalina_home, $::tomcat::manage_catalina_home)
 
   if $source_url and $install_from_source == undef {
     # XXX Backwards compatibility mode enabled; install_from_source used to default
@@ -72,7 +74,7 @@ define tomcat::instance (
     # class created this directory for source installs, even though it may never
     # be used. Users may have created source installs under this directory, so
     # it must exist. tomcat::install::source will take care of creating base.
-    if $_catalina_base != $_catalina_home {
+    if $_catalina_base != $_catalina_home and ! $manage_catalina_home {
       ensure_resource('file',$_catalina_home, {
         ensure => directory,
         owner  => $_user,
@@ -90,6 +92,7 @@ define tomcat::instance (
       group                  => $_group,
       manage_user            => $_manage_user,
       manage_group           => $_manage_group,
+      manage_catalina_home   => $_manage_catalina_home,
       package_ensure         => $package_ensure,
       package_name           => $package_name,
       package_options        => $package_options,

--- a/spec/classes/tomcat_spec.rb
+++ b/spec/classes/tomcat_spec.rb
@@ -58,6 +58,20 @@ describe 'tomcat', :type => :class do
     end
   end
 
+  context "not managing catalina_home" do
+    let :facts do
+      {
+        :osfamily => 'Debian'
+      }
+    end
+    let :params do
+      {
+        :manage_catalina_home => false
+      }
+    end
+    it { is_expected.not_to contain_file("/usr/local/tomcat") }
+  end
+
   context "on windows" do
     let :facts do
       {


### PR DESCRIPTION
Allow the user to choose whether to manage the catalina_directory or not.  This is to support edge cases such as users who need to mount catalina_home from network storage and are already managing the same resource elsewhere