### PR TITLE
MODULES-3742 Bugfix/strict vars service

### DIFF
--- a/manifests/config/server/service.pp
+++ b/manifests/config/server/service.pp
@@ -43,6 +43,8 @@ define tomcat::config::server::service (
       $_class_name = "rm Server/Service[#attribute/name='${name}']/#attribute/className"
     } elsif $class_name {
       $_class_name = "set Server/Service[#attribute/name='${name}']/#attribute/className ${class_name}"
+    } else {
+      $_class_name = undef
     }
     $_service = "set Server/Service[#attribute/name='${name}']/#attribute/name ${name}"
     $changes = delete_undef_values([$_service, $_class_name])

--- a/spec/defines/config/server/service_spec.rb
+++ b/spec/defines/config/server/service_spec.rb
@@ -49,6 +49,22 @@ describe 'tomcat::config::server::service', :type => :define do
       }
     end
   end
+  context 'service ensure without class_name' do
+    let :params do
+      {
+        :catalina_base  => '/opt/apache-tomcat/test',
+        :service_ensure => 'present'
+      }
+    end
+    it { is_expected.to contain_augeas('server-/opt/apache-tomcat/test-service-Catalina').with(
+      'lens' => 'Xml.lns',
+      'incl'    => '/opt/apache-tomcat/test/conf/server.xml',
+      'changes' => [
+        'set Server/Service[#attribute/name=\'Catalina\']/#attribute/name Catalina',
+      ]
+    )
+    }
+  end
   context 'remove service' do
     let :params do
       {


### PR DESCRIPTION
tomcat::config::server::service { $serviceName: 
 catalina_base => $catalina_base,
 service_ensure => 'present', 
}

will raise an error with strict variables = true:

Evaluation Error: Unknown variable: '_class_name'. at
