### PR TITLE
(MODULES-3713) Allow catalina_home and catalina_base to be unmanaged

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ Determines whether defines should default to creating the specified group, if it
 
 Determines whether defines should default to creating the specified user, if it doesn't exist. Uses Puppet's native [`user` resource type](https://docs.puppetlabs.com/references/latest/type.html#user) with default parameters. Valid options: 'true' and 'false'. Default: 'true'.
 
+##### `manage_base`
+Specifies the default value of `manage_base` for all `tomcat::install` instances. Default: `true`
+
+##### `manage_home`
+Specifies the default value of `manage_home` for all `tomcat::instance` instances. Default: `true`
+
 #####`purge_connectors`
 
 Specifies whether to purge any unmanaged Connector elements that match defined protocol but have a different port from the configuration file by default. Valid options: 'true' and 'false'. Default: 'false'.
@@ -846,6 +852,9 @@ Specifies whether the user should be managed by this module or not. Default: `$:
 ##### `manage_group`
 Specifies whether the group should be managed by this module or not. Default: `$::tomcat::manage_group`
 
+##### `manage_home`
+Specifies whether the directory of catalina\_home should be managed by puppet. This may not be preferable in network filesystem environments. Default: `true`
+
 ##### `package_ensure`
 Determines whether the specified package should be installed. Only valid if `install_from_source` is set to `false`. Maps to the `ensure` parameter of Puppet's native [`package` resource type](https://docs.puppetlabs.com/references/latest/type.html#package). Default: 'present'.
 
@@ -884,6 +893,9 @@ Specifies whether the user should be managed by this module or not. Default: `$:
 
 ##### `manage_group`
 Specifies whether the group should be managed by this module or not. Default: `$::tomcat::manage_group`
+
+##### `manage_base`
+Specifies whether the directory of catalina\_base should be managed by puppet. This may not be preferable in network filesystem environments. Default: `true`
 
 ##### `manage_service`
 Specifies whether a `tomcat::service` corresponding to this instance should be declared. Defaults to true for multi-instance installs and false for single-instance installs.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,12 +34,16 @@ class tomcat (
   $purge_realms        = false,
   $manage_user         = true,
   $manage_group        = true,
+  $manage_home         = true,
+  $manage_base         = true,
 ) inherits ::tomcat::params {
   validate_bool($install_from_source)
   validate_bool($purge_connectors)
   validate_bool($purge_realms)
   validate_bool($manage_user)
   validate_bool($manage_group)
+  validate_bool($manage_home)
+  validate_bool($manage_base)
 
   case $::osfamily {
     'windows','Solaris','Darwin': {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,6 +10,7 @@ define tomcat::install (
   $group                  = undef,
   $manage_user            = undef,
   $manage_group           = undef,
+  $manage_home            = undef,
 
   # package options
   $package_ensure         = undef,
@@ -22,6 +23,7 @@ define tomcat::install (
   $_group = pick($group, $::tomcat::group)
   $_manage_user = pick($manage_user, $::tomcat::manage_user)
   $_manage_group = pick($manage_group, $::tomcat::manage_group)
+  $_manage_home = pick($manage_home, $::tomcat::manage_home)
   validate_bool($_install_from_source, $source_strip_first_dir)
   tag(sha1($catalina_home))
 
@@ -39,6 +41,7 @@ define tomcat::install (
     }
     tomcat::install::source { $name:
       catalina_home          => $catalina_home,
+      manage_home            => $_manage_home,
       source_url             => $source_url,
       source_strip_first_dir => $source_strip_first_dir,
       user                   => $_user,

--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -11,6 +11,7 @@
 #   > 0.4.0
 define tomcat::install::source (
   $catalina_home,
+  $manage_home,
   $source_url,
   $source_strip_first_dir,
   $user,
@@ -29,10 +30,12 @@ define tomcat::install::source (
 
   $filename = regsubst($source_url, '.*/(.*)', '\1')
 
-  file { $catalina_home:
-    ensure => directory,
-    owner  => $user,
-    group  => $group,
+  if $manage_home {
+    file { $catalina_home:
+      ensure => directory,
+      owner  => $user,
+      group  => $group,
+    }
   }
 
   ensure_resource('staging::file',$filename, {
@@ -43,7 +46,7 @@ define tomcat::install::source (
     source  => "${::staging::path}/tomcat/${filename}",
     target  => $catalina_home,
     require => Staging::File[$filename],
-    unless  => "test \"\$(ls -A ${catalina_home})\"",
+    unless  => "test -f ${catalina_home}/NOTICE",
     user    => $user,
     group   => $group,
     strip   => $_strip,

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -106,4 +106,73 @@ describe 'tomcat::instance', :type => :define do
     it { is_expected.to compile }
     it { is_expected.to_not contain_file('/opt/apache-tomcat/foo') }
   end
+  context "install from source, unmanaged home" do
+    let :pre_condition do
+      'tomcat::install { "tomcat6":
+        catalina_home => "/opt/apache-tomcat",
+        manage_home   => false,
+        source_url    => "http://mirror.nexcess.net/apache/tomcat/tomcat-8/v8.0.8/bin/apache-tomcat-8.0.8.tar.gz",
+      }'
+    end
+    let :facts do default_facts end
+    let :params do
+      {
+        catalina_home: '/opt/apache-tomcat',
+        catalina_base: '/opt/apache-tomcat/foo',
+      }
+    end
+    it { is_expected.not_to contain_file('/opt/apache-tomcat') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo') }
+  end
+  context "install from source, unmanaged base" do
+    let :pre_condition do
+      'tomcat::install { "tomcat6":
+        catalina_home => "/opt/apache-tomcat",
+        source_url    => "http://mirror.nexcess.net/apache/tomcat/tomcat-8/v8.0.8/bin/apache-tomcat-8.0.8.tar.gz",
+      }'
+    end
+    let :facts do default_facts end
+    let :params do
+      {
+        catalina_home: '/opt/apache-tomcat',
+        catalina_base: '/opt/apache-tomcat/foo',
+        manage_base: false,
+      }
+    end
+    it { is_expected.to contain_file('/opt/apache-tomcat') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo') }
+  end
+  context "install from source, unmanaged home and base" do
+    let :pre_condition do
+      'tomcat::install { "tomcat6":
+        catalina_home => "/opt/apache-tomcat",
+        manage_home   => false,
+        source_url    => "http://mirror.nexcess.net/apache/tomcat/tomcat-8/v8.0.8/bin/apache-tomcat-8.0.8.tar.gz",
+      }'
+    end
+    let :facts do default_facts end
+    let :params do
+      {
+        catalina_home: '/opt/apache-tomcat',
+        catalina_base: '/opt/apache-tomcat/foo',
+        manage_base: false,
+      }
+    end
+    it { is_expected.not_to contain_file('/opt/apache-tomcat') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo') }
+  end
+  context "legacy install from source, unmanaged home/base" do
+    let :pre_condition do
+      'class { "tomcat": }'
+    end
+    let :facts do default_facts end
+    let :params do
+      {
+        catalina_base: '/opt/apache-tomcat/foo',
+        manage_base: false,
+      }
+    end
+    it { is_expected.not_to contain_file('/opt/apache-tomcat') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo') }
+  end
 end


### PR DESCRIPTION
This also includes the ability for the legacy deployment style (that
declares tomcat::instance resources but no tomcat::installs from which
to create the instances) and considereds the base and home to be
identical, since they are undifferentiated in the legacy deployments.

Via #160