### PR TITLE
MODULES-4004 allow undef native tomcat service

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,7 +930,7 @@ Specifies whether to enable the Tomcat service at boot. Only valid if `use_init`
 
 #####`service_ensure`
 
-Specifies whether the Tomcat service should be running. Maps to the `ensure` parameter of Puppet's native [`service` resource type](https://docs.puppetlabs.com/references/latest/type.html#service). Valid options: 'running', 'stopped', 'true', and 'false'. Default: 'present'.
+Specifies whether the Tomcat service should be running. Maps to the `ensure` parameter of Puppet's native [`service` resource type](https://docs.puppetlabs.com/references/latest/type.html#service). Valid options: 'running', 'stopped', 'true', and 'false'. Default: undef.
 
 #####`service_name`
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -30,7 +30,7 @@ define tomcat::service (
   $use_jsvc       = false,
   $use_init       = false,
   $java_home      = undef,
-  $service_ensure = running,
+  $service_ensure = undef,
   $service_enable = undef,
   $service_name   = undef,
   $start_command  = undef,

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -12,6 +12,32 @@ describe 'tomcat::service', :type => :define do
   let :title do
     'default'
   end
+  context 'explicit service ensure running' do
+    let :params do
+      {
+        :service_ensure => 'running',
+      }
+    end
+    it { is_expected.to contain_service('tomcat-default').with(
+      'hasstatus'  => false,
+      'hasrestart' => false,
+      'ensure'     => 'running',
+    )
+    }
+  end
+  context 'explicit service ensure stopped' do
+    let :params do
+      {
+        :service_ensure => 'stopped',
+      }
+    end
+    it { is_expected.to contain_service('tomcat-default').with(
+      'hasstatus'  => false,
+      'hasrestart' => false,
+      'ensure'     => 'stopped',
+    )
+    }
+  end
   context 'using jsvc' do
     let :params do
       {
@@ -21,7 +47,7 @@ describe 'tomcat::service', :type => :define do
     it { is_expected.to contain_service('tomcat-default').with(
       'hasstatus'  => false,
       'hasrestart' => false,
-      'ensure'     => 'running',
+      'ensure'     => nil,
     )
     }
   end
@@ -36,7 +62,7 @@ describe 'tomcat::service', :type => :define do
     it { is_expected.to contain_service('tomcat-default').with(
       'hasstatus'  => false,
       'hasrestart' => false,
-      'ensure'     => 'running',
+      'ensure'     => nil,
       'start'      => '/bin/true',
       'stop'       => '/bin/true',
     )
@@ -80,7 +106,7 @@ describe 'tomcat::service', :type => :define do
     it { is_expected.to contain_service('tomcat-default').with(
       'hasstatus'  => true,
       'hasrestart' => true,
-      'ensure'     => 'running',
+      'ensure'     => nil,
       'start'      => 'service tomcat-default start',
       'stop'       => 'service tomcat-default stop',
     )
@@ -98,7 +124,7 @@ describe 'tomcat::service', :type => :define do
     it { is_expected.to contain_service('tomcat').with(
       'hasstatus'  => true,
       'hasrestart' => true,
-      'ensure'     => 'running',
+      'ensure'     => nil,
       'start'      => '/bin/true',
       'stop'       => '/bin/true',
     )
@@ -108,7 +134,7 @@ describe 'tomcat::service', :type => :define do
     it { is_expected.to contain_service('tomcat-default').with(
       'hasstatus'  => false,
       'hasrestart' => false,
-      'ensure'     => 'running',
+      'ensure'     => nil,
       'start'      => "su -s /bin/bash -c 'CATALINA_HOME=/opt/apache-tomcat CATALINA_BASE=/opt/apache-tomcat /opt/apache-tomcat/bin/catalina.sh start' tomcat",
       'stop'       => "su -s /bin/bash -c 'CATALINA_HOME=/opt/apache-tomcat CATALINA_BASE=/opt/apache-tomcat /opt/apache-tomcat/bin/catalina.sh stop' tomcat",
     )
@@ -124,7 +150,7 @@ describe 'tomcat::service', :type => :define do
     it { is_expected.to contain_service('tomcat-default').with(
       'hasstatus'  => false,
       'hasrestart' => false,
-      'ensure'     => 'running',
+      'ensure'     => nil,
       'start'      => '/bin/true',
       'stop'       => '/bin/true',
     )


### PR DESCRIPTION
Unable to assign native puppet service to undef to achieve the
effect of puppet not changing the current state of the service.
* Change service_ensure default for tomcat::service
* Modify expectations for default in spec tests
* Add check for explicit 'running' and 'stopped'