### PR TITLE
(MODULES-4153) Fix duplicate resources; unfix umask

### DIFF
--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -42,16 +42,6 @@ define tomcat::install::source (
     'source' => $source_url,
   })
 
-  # FM-5578 workaround for strict umodes
-  ensure_resource('file', "${::staging::path}/tomcat", {
-    'ensure' => 'directory',
-    'mode'   => '0755'
-  })
-  ensure_resource('file', "${::staging::path}/tomcat/${filename}", {
-    'mode'    => '0644',
-    'require' => "Exec[${::staging::path}/tomcat/${filename}]",
-  })
-
   staging::extract { "${name}-${filename}":
     source  => "${::staging::path}/tomcat/${filename}",
     target  => $catalina_home,


### PR DESCRIPTION
staging::file will download a file as the puppet daemon user (root) and
then staging::extract will extract the file as the specified user (eg
tomcat). In the case of strict umasks 0077 the downloaded file would be
root:root 600 and thus inaccessible to the tomcat user. The fix was to
manage the mode from the tomcat module to work around the fact that the
staging module was no longer receiving features. This only worked for
http downloads and caused duplicate declarations for puppet://
downloads.

This patch undoes the umask "fix" since it breaks other download modes.
The appropriate fix at this point is to migrate tomcat to puppet-archive
which does not have this issue, but is backwards-incompatible.