### PR TITLE
#[puppethack] Fix MODULES-1986

### DIFF
--- a/manifests/setenv/entry.pp
+++ b/manifests/setenv/entry.pp
@@ -68,9 +68,9 @@ define tomcat::setenv::entry (
   }
 
   if $addto {
-    $_content = inline_template('<%= @_doexport %> <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char %> ; <%= @_doexport %> <%= @addto %>="$<%= @addto %> $<%= @param %>"')
+    $_content = inline_template('<%= @_doexport %> <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char}"\n" %> ; <%= @_doexport %> <%= @addto %>="$<%= @addto %> $<%= @param %>"')
   } else {
-    $_content = inline_template('<%= @_doexport %> <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char %>')
+    $_content = inline_template('<%= @_doexport %> <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char+"\n" %>')
   }
   concat::fragment { "setenv-${name}":
     ensure  => $ensure,


### PR DESCRIPTION
Added newline to the inline template assigned to $_content. This has been
applied to both potential values that $_content can be set to.

Implemented fix that was suggested in the MODULES-1986 ticket