### PR TITLE
MODULES-4261: Allow newer puppet-staging module in depenedencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 < 3.0.0"},
-    {"name":"puppet/staging","version_requirement":">= 0.4.1 < 2.0.0"}
+    {"name":"puppet/staging","version_requirement":">= 0.4.1 < 3.0.0"}
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
This PR just updates metadata.json to allow puppet-staging < 3.0.0 rather than < 2.0.0

Given that the `.fixtures.yml` already pulls the latest puppet-staging from github, and the code has therefore been running against puppet-staging 2.x during travis runs, this should have no impact other than increased compatibility with other modules.
