### PR TITLE
Ability to not manage catalina.properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,9 @@ Specifies the default value of `manage_base` for all `tomcat::install` instances
 ##### `manage_home`
 Specifies the default value of `manage_home` for all `tomcat::instance` instances. Default: `true`
 
+##### `manage_properties`
+Specifies the default value of `manage_properties` for all `tomcat::instance` instances. Default: `true`
+
 #####`purge_connectors`
 
 Specifies whether to purge any unmanaged Connector elements that match defined protocol but have a different port from the configuration file by default. Valid options: 'true' and 'false'. Default: 'false'.
@@ -918,6 +921,9 @@ Specifies whether the directory of catalina\_base should be managed by puppet. T
 
 ##### `manage_service`
 Specifies whether a `tomcat::service` corresponding to this instance should be declared. Defaults to true for multi-instance installs and false for single-instance installs.
+
+##### `manage_properties`
+Specifies whether the `catalina.properties` file is created and managed. If true, custom modifications to this file will be overwritten during runs. Defaults to true.
 
 ##### `java_home`
 Specifies the java home to be used when declaring a `tomcat::service` instance. See [tomcat::service](#tomcatservice)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,8 @@
 # [*manage_group*]
 #   Boolean specifying whether or not to manage the group. Defaults to true.
 #
+# [*manage_properties*]
+#   Boolean specifying whether or not to manage the catalina.properties file. Defaults to true.
 class tomcat (
   $catalina_home       = $::tomcat::params::catalina_home,
   $user                = $::tomcat::params::user,
@@ -36,6 +38,7 @@ class tomcat (
   $manage_group        = true,
   $manage_home         = true,
   $manage_base         = true,
+  $manage_properties   = true,
 ) inherits ::tomcat::params {
   validate_bool($install_from_source)
   validate_bool($purge_connectors)

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -31,6 +31,7 @@ define tomcat::instance (
   $manage_group           = undef,
   $manage_service         = undef,
   $manage_base            = undef,
+  $manage_properties      = undef,
   $java_home              = undef,
   $use_jsvc               = undef,
   $use_init               = undef,
@@ -53,6 +54,7 @@ define tomcat::instance (
   $_manage_user = pick($manage_user, $::tomcat::manage_user)
   $_manage_group = pick($manage_group, $::tomcat::manage_group)
   $_manage_base = pick($manage_base, $::tomcat::manage_base)
+  $_manage_properties = pick($manage_properties, $::tomcat::manage_properties)
 
   if $source_url and $install_from_source == undef {
     # XXX Backwards compatibility mode enabled; install_from_source used to default
@@ -150,11 +152,13 @@ define tomcat::instance (
         user          => $_user,
         group         => $_group,
       }
-      tomcat::config::properties { "${_catalina_base} catalina.properties":
-        catalina_home => $_catalina_home,
-        catalina_base => $_catalina_base,
-        user          => $_user,
-        group         => $_group,
+      if $_manage_properties {
+        tomcat::config::properties { "${_catalina_base} catalina.properties":
+          catalina_home => $_catalina_home,
+          catalina_base => $_catalina_base,
+          user          => $_user,
+          group         => $_group,
+        }
       }
     }
     $_manage_service = pick($manage_service, true)

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -161,6 +161,23 @@ describe 'tomcat::instance', :type => :define do
     it { is_expected.not_to contain_file('/opt/apache-tomcat') }
     it { is_expected.not_to contain_file('/opt/apache-tomcat/foo') }
   end
+  context "install from source, unmanaged catalina.properties" do
+    let :pre_condition do
+      'tomcat::install { "tomcat6":
+        catalina_home => "/opt/apache-tomcat",
+        source_url    => "http://mirror.nexcess.net/apache/tomcat/tomcat-8/v8.0.8/bin/apache-tomcat-8.0.8.tar.gz",
+      }'
+    end
+    let :facts do default_facts end
+    let :params do
+      {
+        catalina_home: '/opt/apache-tomcat',
+        catalina_base: '/opt/apache-tomcat/foo',
+        manage_properties: false,
+      }
+    end
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/conf/catalina.properties') }
+  end
   context "legacy install from source, unmanaged home/base" do
     let :pre_condition do
       'class { "tomcat": }'


### PR DESCRIPTION
In our use case, we need to manage the `catalina.properties` file ourselves. This minor change will simply allow the user to disable the module's handling of `catalina.properties` for a given Tomcat instance.