### PR TITLE
(FM-6166) - Removing concat-fragment 'ensure' for unit tests and updating tar mirror for acceptance tests

### DIFF
--- a/manifests/setenv/entry.pp
+++ b/manifests/setenv/entry.pp
@@ -74,7 +74,6 @@ define tomcat::setenv::entry (
     $_content = inline_template('<%= @_doexport %> <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char+"\n" %>')
   }
   concat::fragment { "setenv-${name}":
-    ensure  => $ensure,
     target  => $_config_file,
     content => $_content,
     order   => $order,

--- a/spec/acceptance/acceptance_1a_spec.rb
+++ b/spec/acceptance/acceptance_1a_spec.rb
@@ -177,7 +177,7 @@ describe 'Acceptance case one', :unless => stop_test do
     end
     it 'Should not have deployed the war' do
       shell('curl localhost:80/war_one/hello.jsp', :acceptable_exit_codes => 0) do |r|
-        r.stdout.should match(/The requested resource is not available/)
+        r.stdout.should match(/The origin server did not find a current representation for the target resource/)
       end
     end
     it 'Should still have the server running on port 80' do

--- a/spec/defines/setenv/entry_spec.rb
+++ b/spec/defines/setenv/entry_spec.rb
@@ -24,7 +24,6 @@ describe 'tomcat::setenv::entry', :type => :define do
 
     it { is_expected.to contain_concat('/opt/apache-tomcat/bin/setenv.sh') }
     it { is_expected.to contain_concat__fragment('setenv-FOO').with_content(/export FOO=\/bin\/true/).with({
-      'ensure' => 'present',
       'target' => '/opt/apache-tomcat/bin/setenv.sh',
     })
     }
@@ -41,7 +40,6 @@ describe 'tomcat::setenv::entry', :type => :define do
 
     it { is_expected.to contain_concat('/opt/apache-tomcat/foo/bin/setenv.sh') }
     it { is_expected.to contain_concat__fragment('setenv-FOO').with_content(/export BAR="\/bin\/true"/).with({
-      'ensure' => 'present',
       'target' => '/opt/apache-tomcat/foo/bin/setenv.sh',
     })
     }
@@ -50,13 +48,11 @@ describe 'tomcat::setenv::entry', :type => :define do
     let :params do
       {
         'value'  => '/bin/true',
-        'ensure' => 'absent',
       }
     end
 
     it { is_expected.to contain_concat('/opt/apache-tomcat/bin/setenv.sh') }
     it { is_expected.to contain_concat__fragment('setenv-FOO').with({
-      'ensure' => 'absent',
       'target' => '/opt/apache-tomcat/bin/setenv.sh',
     })
     }
@@ -87,7 +83,6 @@ describe 'tomcat::setenv::entry', :type => :define do
 
     it { is_expected.to contain_concat('/opt/apache-tomcat/foo/bin/setenv.sh') }
     it { is_expected.to contain_concat__fragment('setenv-FOO').with_content(/export BAR="\/bin\/true \/bin\/false"/).with({
-      'ensure' => 'present',
       'target' => '/opt/apache-tomcat/foo/bin/setenv.sh',
     })
     }
@@ -103,7 +98,6 @@ describe 'tomcat::setenv::entry', :type => :define do
 
     it { is_expected.to contain_concat('/opt/apache-tomcat/bin/setenv.sh') }
     it { is_expected.to contain_concat__fragment('setenv-FOO').with_content(/export BAR=\/bin\/true/).with({
-      'ensure' => 'present',
       'target' => '/opt/apache-tomcat/bin/setenv.sh',
       'order'  => '10',
     })

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -27,11 +27,11 @@ else # We're outside the CI system and use default locations
   latest8 = (match = latest_download_page.match(/apache-tomcat-(.{4,7}).tar.gz/) and match[1])
 
   TOMCAT6_RECENT_VERSION = ENV['TOMCAT6_RECENT_VERSION'] || latest6
-  TOMCAT6_RECENT_SOURCE = "http://mirror.symnds.com/software/Apache/tomcat/tomcat-6/v#{TOMCAT6_RECENT_VERSION}/bin/apache-tomcat-#{TOMCAT6_RECENT_VERSION}.tar.gz"
+  TOMCAT6_RECENT_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-6/v#{TOMCAT6_RECENT_VERSION}/bin/apache-tomcat-#{TOMCAT6_RECENT_VERSION}.tar.gz"
   TOMCAT7_RECENT_VERSION = ENV['TOMCAT7_RECENT_VERSION'] || latest7
-  TOMCAT7_RECENT_SOURCE = "http://mirror.symnds.com/software/Apache/tomcat/tomcat-7/v#{TOMCAT7_RECENT_VERSION}/bin/apache-tomcat-#{TOMCAT7_RECENT_VERSION}.tar.gz"
+  TOMCAT7_RECENT_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-7/v#{TOMCAT7_RECENT_VERSION}/bin/apache-tomcat-#{TOMCAT7_RECENT_VERSION}.tar.gz"
   TOMCAT8_RECENT_VERSION = ENV['TOMCAT8_RECENT_VERSION'] || latest8
-  TOMCAT8_RECENT_SOURCE = "http://mirror.nexcess.net/apache/tomcat/tomcat-8/v#{TOMCAT8_RECENT_VERSION}/bin/apache-tomcat-#{TOMCAT8_RECENT_VERSION}.tar.gz"
+  TOMCAT8_RECENT_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-8/v#{TOMCAT8_RECENT_VERSION}/bin/apache-tomcat-#{TOMCAT8_RECENT_VERSION}.tar.gz"
   TOMCAT_LEGACY_VERSION = ENV['TOMCAT_LEGACY_VERSION'] || '6.0.39'
   TOMCAT_LEGACY_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-6/v#{TOMCAT_LEGACY_VERSION}/bin/apache-tomcat-#{TOMCAT_LEGACY_VERSION}.tar.gz"
   SAMPLE_WAR = 'https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war'


### PR DESCRIPTION
Due to concat Puppet 4 release, the 'ensure' parameter has now been
deprecated. Removing the 'ensure' parameter within concat-fragmentfrom the code base.