### PR TITLE
(MODULES-4658) Allow duplicate realms

### DIFF
--- a/manifests/config/server/realm.pp
+++ b/manifests/config/server/realm.pp
@@ -3,22 +3,25 @@
 # Configure Realm elements in $CATALINA_BASE/conf/server.xml
 #
 # Parameters:
-# - $catalina_base is the base directory for the Tomcat installation.
-# - $class_name is the Java class name of the Realm implementation to use.
-# - $realm_ensure specifies whether you are adding or removing a
-#   Realm element. Valid values are 'true', 'false', 'present', and
-#   'absent'. Defaults to 'present'.
-# - $parent_service is the `name` attribute for the Service element this Realm
-#   should be nested beneath. Defaults to 'Catalina'.
-# - $parent_engine is the `name` attribute for the Engine element this Realm
-#   should be nested beneath. Defaults to 'Catalina'.
-# - $parent_host is the `name` attribute for the Host element this Realm
-#   should be nested beneath.
-# - $parent_realm is the `name` attribute for the Realm element this Realm
-#   should be nested beneath.
-# - An optional hash of $additional_attributes to add to the Realm. Should
-#   be of the format 'attribute' => 'value'.
-# - An optional array of $attributes_to_remove from the Realm.
+# @param catalina_base is the base directory for the Tomcat installation.
+# @param class_name is the Java class name of the Realm implementation to use.
+# @param realm_ensure specifies whether you are adding or removing a
+#        Realm element. Valid values are 'true', 'false', 'present', and
+#        'absent'. Defaults to 'present'.
+# @param parent_service is the `name` attribute for the Service element this Realm
+#        should be nested beneath. Defaults to 'Catalina'.
+# @param parent_engine is the `name` attribute for the Engine element this Realm
+#        should be nested beneath. Defaults to 'Catalina'.
+# @param parent_host is the `name` attribute for the Host element this Realm
+#        should be nested beneath.
+# @param parent_realm is the `name` attribute for the Realm element this Realm
+#        should be nested beneath.
+# @param additional_attributes An optional hash of additional attributes to add to the Realm.
+#        Should be of the format 'attribute' => 'value'.
+# @param attributes_to_remove An optional array of attributes to remove from the Realm.
+# @param purge_realms Specifies whether to purge any unmanaged realm elements
+#        from the configuration file by default.
+# @param server_config Specifies a server.xml file to manage.
 define tomcat::config::server::realm (
   $catalina_base         = undef,
   $class_name            = $name,
@@ -32,7 +35,7 @@ define tomcat::config::server::realm (
   $purge_realms          = undef,
   $server_config         = undef,
 ) {
-  include tomcat
+  include ::tomcat
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
   tag(sha1($_catalina_base))
   $_purge_realms = pick($purge_realms, $::tomcat::purge_realms)
@@ -75,8 +78,7 @@ define tomcat::config::server::realm (
   # The Realm could also be nested under another Realm element if the parent realm is a CombinedRealm.
   if $parent_realm {
     $path = "${host_path}/Realm[#attribute/className='${parent_realm}']/Realm"
-  }
-  else {
+  } else {
     $path = "${host_path}/Realm"
   }
 
@@ -86,25 +88,32 @@ define tomcat::config::server::realm (
     $_server_config = "${_catalina_base}/conf/server.xml"
   }
 
-  if $realm_ensure =~ /^(absent|false)$/ {
-    $changes = "rm ${path}[#attribute/className='${class_name}']"
-  }
-  else {
+  # For backwards-compatible reasons, match previously managed realms that do
+  # not have puppetName but have a known className. Either we match puppetName
+  # or className; puppet could not have created a state in which two realms
+  # match.
+  $path_expression = "#attribute/puppetName='${name}' or (count(#attribute/puppetName)=0 and #attribute/className='${class_name}')"
 
-    $_class_name = "set ${path}[#attribute/className='${class_name}']/#attribute/className ${class_name}"
+  if $realm_ensure =~ /^(absent|false)$/ {
+    $changes = "rm ${path}[${path_expression}]"
+  } else {
+
+    # This will create the node if there are no matches
+    $_class_name = "set ${path}[${path_expression}]/#attribute/className ${class_name}"
+    $puppet_name = "set ${path}[${path_expression}]/#attribute/puppetName ${name}"
 
     if ! empty($additional_attributes) {
-      $_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${path}[#attribute/className='${class_name}']/#attribute/"), "'")
+      $_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${path}[${path_expression}]/#attribute/"), "'")
     } else {
       $_additional_attributes = undef
     }
     if ! empty(any2array($attributes_to_remove)) {
-      $_attributes_to_remove = prefix(any2array($attributes_to_remove), "rm ${path}[#attribute/className='${class_name}']/#attribute/")
+      $_attributes_to_remove = prefix(any2array($attributes_to_remove), "rm ${path}[${path_expression}]/#attribute/")
     } else {
       $_attributes_to_remove = undef
     }
 
-    $changes = delete_undef_values(flatten([ $__purge_realms, $_class_name, $_additional_attributes, $_attributes_to_remove ]))
+    $changes = delete_undef_values(flatten([ $__purge_realms, $puppet_name, $_class_name, $_additional_attributes, $_attributes_to_remove ]))
   }
 
   augeas { "${_catalina_base}-${parent_service}-${parent_engine}-${parent_host}-${parent_realm}-realm-${name}":

--- a/spec/acceptance/acceptance_1a_spec.rb
+++ b/spec/acceptance/acceptance_1a_spec.rb
@@ -179,7 +179,7 @@ describe 'Acceptance case one', :unless => stop_test do
     end
     it 'Should not have deployed the war' do
       shell('curl localhost:80/war_one/hello.jsp', :acceptable_exit_codes => 0) do |r|
-        r.stdout.should match(/The requested resource is not available./)
+        r.stdout.should match(/The requested resource is not available/)
       end
     end
     it 'Should still have the server running on port 80' do

--- a/spec/acceptance/acceptance_4a_spec.rb
+++ b/spec/acceptance/acceptance_4a_spec.rb
@@ -82,7 +82,7 @@ describe 'Use two realms within a configuration', :unless => stop_test do
     end
     it 'Should contain two realms in config file' do
       shell('cat /opt/apache-tomcat/tomcat40/conf/server.xml', :acceptable_exit_codes => 0) do |r|
-        r.stdout.should match(/<Realm className="org.apache.catalina.realm.MemoryRealm"><\/Realm>/)
+        r.stdout.should match(/<Realm puppetName="org.apache.catalina.realm.MemoryRealm" className="org.apache.catalina.realm.MemoryRealm"><\/Realm>/)
       end
     end
     it 'should be idempotent' do

--- a/spec/defines/config/server/realm_spec.rb
+++ b/spec/defines/config/server/realm_spec.rb
@@ -37,14 +37,15 @@ describe 'tomcat::config::server::realm', :type => :define do
       'lens'    => 'Xml.lns',
       'incl'    => '/opt/apache-tomcat/server.xml',
       'changes' => [
-        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/className org.apache.catalina.realm.JNDIRealm",
-        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/connectionURL 'ldap://localhost'",
-        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/roleName 'cn'",
-        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/roleSearch 'member={0}'",
-        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/spaces 'foo bar'",
-        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/foo",
-        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/bar",
-        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/baz",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/puppetName org.apache.catalina.realm.JNDIRealm",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/className org.apache.catalina.realm.JNDIRealm",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/connectionURL 'ldap://localhost'",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/roleName 'cn'",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/roleSearch 'member={0}'",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/spaces 'foo bar'",
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/foo",
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/bar",
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/baz",
       ]
     )
     }
@@ -75,11 +76,12 @@ describe 'tomcat::config::server::realm', :type => :define do
         "rm //Host//Realm",
         "rm //Engine//Realm",
         "rm //Server//Realm",
-        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/className org.apache.catalina.realm.JNDIRealm",
-        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/connectionURL 'ldap://localhost'",
-        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/roleName 'cn'",
-        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/foo",
-        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/bar",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/puppetName org.apache.catalina.realm.JNDIRealm",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/className org.apache.catalina.realm.JNDIRealm",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/connectionURL 'ldap://localhost'",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/roleName 'cn'",
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/foo",
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/bar",
       ]
     )
     }
@@ -98,7 +100,8 @@ describe 'tomcat::config::server::realm', :type => :define do
       'lens' => 'Xml.lns',
       'incl' => '/opt/apache-tomcat/test/conf/server.xml',
       'changes' => [
-        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/className org.apache.catalina.realm.JNDIRealm",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/puppetName org.apache.catalina.realm.JNDIRealm",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/className org.apache.catalina.realm.JNDIRealm",
       ]
     )
     }
@@ -127,7 +130,8 @@ describe 'tomcat::config::server::realm', :type => :define do
       'lens' => 'Xml.lns',
       'incl' => '/opt/apache-tomcat/test/conf/server.xml',
       'changes' => [
-        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/className org.apache.catalina.realm.JNDIRealm",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='first' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/puppetName first",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='first' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/className org.apache.catalina.realm.JNDIRealm",
       ]
     )
     }
@@ -135,7 +139,8 @@ describe 'tomcat::config::server::realm', :type => :define do
       'lens' => 'Xml.lns',
       'incl' => '/opt/apache-tomcat/test/conf/server.xml',
       'changes' => [
-        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/className org.apache.catalina.realm.JNDIRealm",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='second' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/puppetName second",
+        "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='second' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/className org.apache.catalina.realm.JNDIRealm",
       ]
     )
     }
@@ -154,7 +159,7 @@ describe 'tomcat::config::server::realm', :type => :define do
       'lens' => 'Xml.lns',
       'incl' => '/opt/apache-tomcat/test/conf/server.xml',
       'changes' => [
-        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']",
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.LockOutRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.LockOutRealm')]",
       ]
     )
     }
@@ -173,7 +178,7 @@ describe 'tomcat::config::server::realm', :type => :define do
       'lens' => 'Xml.lns',
       'incl' => '/opt/apache-tomcat/test/conf/server.xml',
       'changes' => [
-        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']",
+        "rm Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/puppetName='org.apache.catalina.realm.LockOutRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.LockOutRealm')]",
       ]
     )
     }
@@ -194,7 +199,8 @@ describe 'tomcat::config::server::realm', :type => :define do
       'lens' => 'Xml.lns',
        'incl' => '/opt/apache-tomcat/test/conf/server.xml',
        'changes' => [
-         "set Server/Service[#attribute/name='NewService']/Engine[#attribute/name='AnotherEngine']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/className org.apache.catalina.realm.JNDIRealm",
+         "set Server/Service[#attribute/name='NewService']/Engine[#attribute/name='AnotherEngine']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/puppetName org.apache.catalina.realm.JNDIRealm",
+         "set Server/Service[#attribute/name='NewService']/Engine[#attribute/name='AnotherEngine']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/className org.apache.catalina.realm.JNDIRealm",
        ]
     )
     }
@@ -214,7 +220,8 @@ describe 'tomcat::config::server::realm', :type => :define do
       'lens' => 'Xml.lns',
        'incl' => '/opt/apache-tomcat/test/conf/server.xml',
        'changes' => [
-         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Host[#attribute/name='localhost']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/className org.apache.catalina.realm.JNDIRealm",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Host[#attribute/name='localhost']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/puppetName org.apache.catalina.realm.JNDIRealm",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Host[#attribute/name='localhost']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/className org.apache.catalina.realm.JNDIRealm",
        ]
     )
     }
@@ -235,7 +242,8 @@ describe 'tomcat::config::server::realm', :type => :define do
       'lens' => 'Xml.lns',
        'incl' => '/opt/apache-tomcat/test/conf/server.xml',
        'changes' => [
-         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Host[#attribute/name='localhost']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/className org.apache.catalina.realm.JNDIRealm",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Host[#attribute/name='localhost']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/puppetName org.apache.catalina.realm.JNDIRealm",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Host[#attribute/name='localhost']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/className org.apache.catalina.realm.JNDIRealm",
        ]
     )
     }
@@ -261,11 +269,12 @@ describe 'tomcat::config::server::realm', :type => :define do
       'lens' => 'Xml.lns',
        'incl' => '/opt/apache-tomcat/test/conf/server.xml',
        'changes' => [
-         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/className org.apache.catalina.realm.JNDIRealm",
-         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/connectionURL 'ldap://localhost'",
-         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/roleName 'cn'",
-         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/roleSearch 'member={0}'",
-         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.JNDIRealm']/#attribute/spaces 'foo bar'",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/puppetName org.apache.catalina.realm.JNDIRealm",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/className org.apache.catalina.realm.JNDIRealm",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/connectionURL 'ldap://localhost'",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/roleName 'cn'",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/roleSearch 'member={0}'",
+         "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/spaces 'foo bar'",
        ]
     )
     }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -19,19 +19,19 @@ if ENV['BUILD_ID'] # We're in our CI system and use internal resources
 
 else # We're outside the CI system and use default locations
   require 'net/http'
-  latest_download_page = Net::HTTP.get(URI('http://tomcat.apache.org/download-60.cgi?Preferred=http%3A%2F%2Fmirror.symnds.com%2Fsoftware%2FApache%2F'))
-  latest6 = (match = latest_download_page.match(/apache-tomcat-(.{4,7}).tar.gz/) and match[1])
-  latest_download_page = Net::HTTP.get(URI('http://tomcat.apache.org/download-70.cgi?Preferred=http%3A%2F%2Fmirror.symnds.com%2Fsoftware%2FApache%2F'))
-  latest7 = (match = latest_download_page.match(/apache-tomcat-(.{4,7}).tar.gz/) and match[1])
-  latest_download_page = Net::HTTP.get(URI('http://tomcat.apache.org/download-80.cgi?Preferred=http%3A%2F%2Fmirror.symnds.com%2Fsoftware%2FApache%2F'))
-  latest8 = (match = latest_download_page.match(/apache-tomcat-(.{4,7}).tar.gz/) and match[1])
+  latest_download_page = Net::HTTP.get(URI('http://tomcat.apache.org/download-60.cgi'))
+  latest6 = (match = latest_download_page.match(%r{https?://.*?apache-tomcat-(.{4,7}).tar.gz}) and match[0])
+  latest_download_page = Net::HTTP.get(URI('http://tomcat.apache.org/download-70.cgi'))
+  latest7 = (match = latest_download_page.match(%r{https?://.*?apache-tomcat-(.{4,7}).tar.gz}) and match[0])
+  latest_download_page = Net::HTTP.get(URI('http://tomcat.apache.org/download-80.cgi'))
+  latest8 = (match = latest_download_page.match(%r{https?://.*?apache-tomcat-(.{4,7}).tar.gz}) and match[0])
 
   TOMCAT6_RECENT_VERSION = ENV['TOMCAT6_RECENT_VERSION'] || latest6
-  TOMCAT6_RECENT_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-6/v#{TOMCAT6_RECENT_VERSION}/bin/apache-tomcat-#{TOMCAT6_RECENT_VERSION}.tar.gz"
+  TOMCAT6_RECENT_SOURCE = latest6
   TOMCAT7_RECENT_VERSION = ENV['TOMCAT7_RECENT_VERSION'] || latest7
-  TOMCAT7_RECENT_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-7/v#{TOMCAT7_RECENT_VERSION}/bin/apache-tomcat-#{TOMCAT7_RECENT_VERSION}.tar.gz"
+  TOMCAT7_RECENT_SOURCE = latest7
   TOMCAT8_RECENT_VERSION = ENV['TOMCAT8_RECENT_VERSION'] || latest8
-  TOMCAT8_RECENT_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-8/v#{TOMCAT8_RECENT_VERSION}/bin/apache-tomcat-#{TOMCAT8_RECENT_VERSION}.tar.gz"
+  TOMCAT8_RECENT_SOURCE = latest8
   TOMCAT_LEGACY_VERSION = ENV['TOMCAT_LEGACY_VERSION'] || '6.0.39'
   TOMCAT_LEGACY_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-6/v#{TOMCAT_LEGACY_VERSION}/bin/apache-tomcat-#{TOMCAT_LEGACY_VERSION}.tar.gz"
   SAMPLE_WAR = 'https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war'


### PR DESCRIPTION
Without this PR, the className of a realm may not be unique (eg, in the
case of two ldap authentication realms both using className of
org.apache.catalina.realm.JNDIRealm) and thus augeas happily overwrites
the first realm with a second every puppet run.

This adds an extra attribute puppetName based on the resource title to
maintain a uniqueness constraint, and will look for realms with a given
className (the old case) as well as realms with the puppetName. There
can be no more than one unique className managed by puppet currently, so
this handles upgrades by adding a puppetName to those existing realms,
and allowing duplicates after that point.