### PR TITLE
Add flexibility to directory management in tomcat::instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1535,11 +1535,21 @@ Valid options: a string containing an absolute path.
 
 Default value: '$::tomcat::catalina_home'.
 
-##### `user`
+##### `dir_list`
 
-Specifies the owner of the instance directories and files.
+Specifies the subdirectories under `catalina_base` to be managed for an instance (disabled via `manage_dirs` boolean).
 
-Default value: `$::tomcat::user`.
+Valid options: an array of strings, each being a relative subdirectory to `catalina_base`.
+
+Default value: `['bin','conf','lib','logs','temp','webapps','work']`.
+
+##### `dir_mode`
+
+Specifies a mode for the managed subdirectories under `catalina_base` for an instance (as specified in `dir_list` and disabled via `manage_dirs` boolean).
+
+Valid option: a string containing a standard Linux mode.
+
+Default value: '2770'.
 
 ##### `group`
 
@@ -1547,11 +1557,23 @@ Specifies the group of the instance directories and files.
 
 Default value: `$::tomcat::group`.
 
-##### `manage_user`
+##### `java_home`
 
-Specifies whether the user should be managed by this module or not.
+Specifies the java home to be used when declaring a `tomcat::service` instance. See [tomcat::service](# tomcatservice)
 
-Default value: `$::tomcat::manage_user`.
+##### `manage_base`
+
+Specifies whether the directory of catalina_base should be managed by puppet. This may not be preferable in network filesystem environments.
+
+Default value: `true`.
+
+##### `manage_dirs`
+
+Determines whether subdirectories for `catalina_base` should be managed as part of tomcat::instance. The default directories are listed in `dir_list`.
+
+Valid options: `true` and `false`.
+
+Default value: `true`.
 
 ##### `manage_group`
 
@@ -1559,9 +1581,11 @@ Specifies whether the group should be managed by this module or not.
 
 Default value: `$::tomcat::manage_group`.
 
-##### `manage_base`
+##### `manage_properties`
 
-Specifies whether the directory of catalina_base should be managed by puppet. This may not be preferable in network filesystem environments.
+Specifies whether the `catalina.properties` file is created and managed. If `true`, custom modifications to this file will be overwritten during runs
+
+Valid options: `true`, `false`
 
 Default value: `true`.
 
@@ -1573,17 +1597,15 @@ Valid options: `true`, `false`
 
 Default value: `true` (multi-instance installs), `false` ()single-instance installs).
 
-##### `manage_properties`
+##### `manage_user`
 
-Specifies whether the `catalina.properties` file is created and managed. If `true`, custom modifications to this file will be overwritten during runs
+Specifies whether the user should be managed by this module or not.
 
-Valid options: `true`, `false`
+Default value: `$::tomcat::manage_user`.
 
-Default value: `true`.
+##### `use_init`
 
-##### `java_home`
-
-Specifies the java home to be used when declaring a `tomcat::service` instance. See [tomcat::service](# tomcatservice)
+Specifies whether an init script should be managed when declaring a `tomcat::service` instance. See [tomcat::service](# tomcatservice)
 
 ##### `use_jsvc`
 
@@ -1591,9 +1613,11 @@ Specifies whether jsvc should be used when declaring a `tomcat::service` instanc
 
 >Note that this module will not compile and install jsvc for you. See [tomcat::service](# tomcatservice)
 
-##### `use_init`
+##### `user`
 
-Specifies whether an init script should be managed when declaring a `tomcat::service` instance. See [tomcat::service](# tomcatservice)
+Specifies the owner of the instance directories and files.
+
+Default value: `$::tomcat::user`.
 
 #### tomcat::service
 

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -189,4 +189,132 @@ describe 'tomcat::instance', :type => :define do
     it { is_expected.not_to contain_file('/opt/apache-tomcat') }
     it { is_expected.not_to contain_file('/opt/apache-tomcat/foo') }
   end
+  context "install from source, managed dirs (default)" do
+    let :pre_condition do
+      'tomcat::install { "tomcat6":
+        catalina_home => "/opt/apache-tomcat",
+        source_url    => "http://mirror.nexcess.net/apache/tomcat/tomcat-8/v8.0.8/bin/apache-tomcat-8.0.8.tar.gz",
+      }'
+    end
+    let :facts do default_facts end
+    let :params do
+      {
+        catalina_home: '/opt/apache-tomcat',
+        catalina_base: '/opt/apache-tomcat/foo',
+      }
+    end
+    it { is_expected.to contain_file('/opt/apache-tomcat') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/bin') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/conf') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/lib') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/temp') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/webapps') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/work') }
+  end
+  context "install from source, unmanaged dirs" do
+    let :pre_condition do
+      'tomcat::install { "tomcat6":
+        catalina_home => "/opt/apache-tomcat",
+        source_url    => "http://mirror.nexcess.net/apache/tomcat/tomcat-8/v8.0.8/bin/apache-tomcat-8.0.8.tar.gz",
+      }'
+    end
+    let :facts do default_facts end
+    let :params do
+      {
+        catalina_home: '/opt/apache-tomcat',
+        catalina_base: '/opt/apache-tomcat/foo',
+        manage_dirs: false,
+      }
+    end
+    it { is_expected.to contain_file('/opt/apache-tomcat') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/bin') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/conf') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/lib') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/logs') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/temp') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/webapps') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/work') }
+  end
+  context "install from source, custom managed dir list" do
+    let :pre_condition do
+      'tomcat::install { "tomcat6":
+        catalina_home => "/opt/apache-tomcat",
+        source_url    => "http://mirror.nexcess.net/apache/tomcat/tomcat-8/v8.0.8/bin/apache-tomcat-8.0.8.tar.gz",
+      }'
+    end
+    let :facts do default_facts end
+    let :params do
+      {
+        catalina_home: '/opt/apache-tomcat',
+        catalina_base: '/opt/apache-tomcat/foo',
+        dir_list: [ 'config','webappstest' ]
+      }
+    end
+    it { is_expected.to contain_file('/opt/apache-tomcat') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/config') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/webappstest') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/bin') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/conf') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/lib') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/logs') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/temp') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/webapps') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/work') }
+  end
+  context "install from source, dir mode" do
+    let :pre_condition do
+      'tomcat::install { "tomcat6":
+        catalina_home => "/opt/apache-tomcat",
+        source_url    => "http://mirror.nexcess.net/apache/tomcat/tomcat-8/v8.0.8/bin/apache-tomcat-8.0.8.tar.gz",
+      }'
+    end
+    let :facts do default_facts end
+    let :params do
+      {
+        catalina_home: '/opt/apache-tomcat',
+        catalina_base: '/opt/apache-tomcat/foo',
+        dir_mode: '0775',
+      }
+    end
+    it { is_expected.to contain_file('/opt/apache-tomcat') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/bin').with_mode('0775') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/conf').with_mode('0775') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/lib').with_mode('0775') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/logs').with_mode('0775') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/temp').with_mode('0775') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/webapps').with_mode('0775') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/work').with_mode('0775') }
+  end
+  context "install from source, dir mode with custom dir list" do
+    let :pre_condition do
+      'tomcat::install { "tomcat6":
+        catalina_home => "/opt/apache-tomcat",
+        source_url    => "http://mirror.nexcess.net/apache/tomcat/tomcat-8/v8.0.8/bin/apache-tomcat-8.0.8.tar.gz",
+      }'
+    end
+    let :facts do default_facts end
+    let :params do
+      {
+        catalina_home: '/opt/apache-tomcat',
+        catalina_base: '/opt/apache-tomcat/foo',
+        dir_list: [ 'config','webappstest' ],
+        dir_mode: '0775',
+      }
+    end
+    it { is_expected.to contain_file('/opt/apache-tomcat') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/config').with_mode('0775') }
+    it { is_expected.to contain_file('/opt/apache-tomcat/foo/webappstest').with_mode('0775') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/bin') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/conf') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/lib') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/logs') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/temp') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/webapps') }
+    it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/work') }
+  end
 end


### PR DESCRIPTION
Some Tomcat installations have non-standard directory layouts under $catalina_base.

Allow disabling $catalina_base sub-directories entirely via $manage_dirs
Allow configuration of which $catalina_base sub-directories are managed vi $dir_list (array)
Allow configuration of the mode for $catalina_base sub-directories.
Retain all defaults (dir_list and mode set in tomcat::params)