### PR TITLE
fix retval checks in init script template

### DIFF
--- a/templates/jsvc-init.erb
+++ b/templates/jsvc-init.erb
@@ -166,7 +166,7 @@ do_status()
 {
   if [ -f $CATALINA_PID ];then
         ps -p `cat $CATALINA_PID` >/dev/null 2>&1
-        if [[ "$?" == "0" ]];then
+        if [ "$?" -eq 0 ];then
             echo "tomcat alive (pid `cat $CATALINA_PID`)..."
             exit 0
         else
@@ -202,7 +202,7 @@ do_version()
      -version \
      -check \
      $CATALINA_MAIN
-  if [ "$?" = 0 ]; then
+  if [ "$?" -eq 0 ]; then
     "$JAVA_BIN" \
       -classpath "$CATALINA_HOME/lib/catalina.jar" \
       org.apache.catalina.util.ServerInfo


### PR DESCRIPTION
The `status` command in the init script is not working:

```
# service tomcat-foobar status
CATALINA_BASE /opt/foobar
CATALINA_HOME /opt/foobar
CATALINA_LOCAL
CATALINA_OPTS 
JAVA_OPTS 
TOMCAT_USER tomcat
/etc/init.d/tomcat-foobar: 169: [: 0: unexpected operator
pidfile exists but tomcat dead
```

And thus the puppet run will fail, although the application was started (or is running) correctly:

```
Error: Could not start Service[tomcat-foobar]: Execution of 'service tomcat-foobar start' returned 1: CATALINA_BASE /opt/foobar
CATALINA_HOME /opt/foobar
CATALINA_LOCAL
CATALINA_OPTS 
JAVA_OPTS 
TOMCAT_USER tomcat
```

This PR fixes the small syntax issues in the init script template.