### PR TITLE
Add support for verifying WAR with SHA1 checksum

### DIFF
--- a/manifests/war.pp
+++ b/manifests/war.pp
@@ -27,6 +27,7 @@ define tomcat::war(
   $war_name        = undef,
   $war_purge       = true,
   $war_source      = undef,
+  $war_sha1sum     = undef,
 ) {
   include tomcat
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
@@ -79,6 +80,12 @@ define tomcat::war(
       extract => false,
       source  => $war_source,
       path    => "${_deployment_path}/${_war_name}",
+      
+      checksum_type => $war_sha1sum ? {
+        undef => 'none',
+        default => 'sha1'
+      },
+      checksum => $war_sha1sum,
     }
   }
 }


### PR DESCRIPTION
WAR file does not appear to update when updates are available.

Please consider updating `archive` declaration to pass optional SHA1 checksum.