### PR TITLE
Force sha256sum on WAR source

### DIFF
--- a/manifests/war.pp
+++ b/manifests/war.pp
@@ -27,6 +27,7 @@ define tomcat::war(
   $war_name        = undef,
   $war_purge       = true,
   $war_source      = undef,
+  $war_sha256sum     = undef,
 ) {
   include tomcat
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
@@ -75,9 +76,12 @@ define tomcat::war(
     if ! $war_source {
       fail('$war_source must be specified if you aren\'t removing the WAR')
     }
-    staging::file { $name:
+
+    file { "${_deployment_path}/${_war_name}": 
       source => $war_source,
-      target => "${_deployment_path}/${_war_name}",
+      
+      checksum => 'sha256',
+      checksum_value => $war_sha256sum,
     }
   }
 }


### PR DESCRIPTION
Please consider redeploying WAR file in `tomcat::war` if checksum differs.

Note: This also replaces `staging::file` with the `file` resource. This has also been tested against Puppet 4.10.1:
````
Notice: /Stage[main]/Profile::Sample::Tomcat/Tomcat::War[sample.war]/File[/opt/tomcat/sample/webapps/sample.war]/content:
Binary files /opt/tomcat/sample/webapps/sample.war and /tmp/puppet-file20170712-89638-gv34zy differ

Notice: /Stage[main]/Profile::Sample::Tomcat/Tomcat::War[sample.war]/File[/opt/tomcat/sample/webapps/sample.war]/content:

Notice: /Stage[main]/Profile::Sample::Tomcat/Tomcat::War[sample.war]/File[/opt/tomcat/sample/webapps/sample.war]/content: content changed '{sha256}b31e4...' to '{sha256}e1ab9...'
````