### PR TITLE
(maint) Don't duplicate resources for different dependencies

### DIFF
--- a/manifests/config/server/tomcat_users.pp
+++ b/manifests/config/server/tomcat_users.pp
@@ -71,8 +71,8 @@ define tomcat::config::server::tomcat_users (
       owner   => $_owner,
       group   => $_group,
       mode    => '0640',
-      before  => Augeas["${catalina_base}-tomcat_users-${element}-${_element_name}-${name}"],
     })
+    File[$_file] -> Augeas["${catalina_base}-tomcat_users-${element}-${_element_name}-${name}"]
   }
 
   $path = "tomcat-users/${element}[#attribute/${element_identifier}='${_element_name}']"

--- a/spec/defines/config/server/tomcat_users_spec.rb
+++ b/spec/defines/config/server/tomcat_users_spec.rb
@@ -48,8 +48,7 @@ describe 'tomcat::config::server::tomcat_users', :type => :define do
         'group'   => 'tomcat',
         'mode'    => '0640',
         'replace' => false,
-        'before'  => 'Augeas[/opt/apache-tomcat/test-tomcat_users-user-foo-user-foo]',
-      })
+      }).that_comes_before('Augeas[/opt/apache-tomcat/test-tomcat_users-user-foo-user-foo]')
     end
   end
   context 'Add User no element' do
@@ -107,8 +106,7 @@ describe 'tomcat::config::server::tomcat_users', :type => :define do
         'mode'    => '0640',
         'replace' => false,
         'content' => '<?xml version=\'1.0\' encoding=\'utf-8\'?><tomcat-users></tomcat-users>',
-        'before'  => 'Augeas[/opt/apache-tomcat/test-tomcat_users-user-foo-user-foo]',
-      })
+      }).that_comes_before('Augeas[/opt/apache-tomcat/test-tomcat_users-user-foo-user-foo]')
     end
   end
   context 'Remove User' do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -12,7 +12,7 @@ def latest_tomcat_tarball_url(version)
   else
     mirror_url = (match = page.match(%r{<strong>(https?://.*?)/</strong>}) and match[1])
     page = Net::HTTP.get(URI("#{mirror_url}/tomcat/tomcat-#{version}/"))
-    latest_version = (match = page.match(%r{<a href="v(.{4,7})/">}) and match[1])
+    latest_version = (match = page.match(%r{href="v(.{4,7})/"}) and match[1])
 
     "#{mirror_url}/tomcat/tomcat-#{version}/v#{latest_version}/bin/apache-tomcat-#{latest_version}.tar.gz"
   end


### PR DESCRIPTION
The file resource is declared with ensure_resource() which does not
cause duplicate resource declarations unless some of the attributes are
different from the already-declared resource.

In the case of this dependency, it will be different for each
declaration of tomcat_user so must be defined separately from the
ensure_resource call.