### PR TITLE
(MODULES-1545) Allow context paths in war_name

### DIFF
--- a/manifests/war.pp
+++ b/manifests/war.pp
@@ -74,10 +74,14 @@ define tomcat::war(
     if ! $war_source {
       fail('$war_source must be specified if you aren\'t removing the WAR')
     }
+    # wget allows context paths to have ## as per
+    # https://tomcat.apache.org/tomcat-8.0-doc/config/context.html whereas curl
+    # does not.
     archive { "tomcat::war ${name}":
-      extract => false,
-      source  => $war_source,
-      path    => "${_deployment_path}/${_war_name}",
+      extract  => false,
+      source   => $war_source,
+      path     => "${_deployment_path}/${_war_name}",
+      provider => 'wget',
     }
   }
 }

--- a/spec/acceptance/acceptance_2b_spec.rb
+++ b/spec/acceptance/acceptance_2b_spec.rb
@@ -72,12 +72,12 @@ describe 'Two different installations with two instances each of Tomcat 6 in the
       tomcat::war { 'first tomcat6-sample.war':
         catalina_base => '/opt/tomcat6-first',
         war_source    => '#{SAMPLE_WAR}',
-        war_name      => 'tomcat6-sample.war',
+        war_name      => 'tomcat6#sample.war',
       }
       tomcat::war { 'second tomcat6-sample.war':
         catalina_base => '/opt/tomcat6-second',
         war_source    => '#{SAMPLE_WAR}',
-        war_name      => 'tomcat6-sample.war',
+        war_name      => 'tomcat6#sample.war',
       }
 
 
@@ -150,12 +150,12 @@ describe 'Two different installations with two instances each of Tomcat 6 in the
     end
     #test the war
     it 'tomcat6-first should have war deployed by default' do
-      shell('curl localhost:8280/tomcat6-sample/hello.jsp', :acceptable_exit_codes => 0) do |r|
+      shell('curl localhost:8280/tomcat6/sample/hello.jsp', :acceptable_exit_codes => 0) do |r|
         expect(r.stdout).to match(/Sample Application JSP Page/)
       end
     end
     it 'tomcat6-second should have war deployed by default' do
-      shell('curl localhost:8281/tomcat6-sample/hello.jsp', :acceptable_exit_codes => 0) do |r|
+      shell('curl localhost:8281/tomcat6/sample/hello.jsp', :acceptable_exit_codes => 0) do |r|
         expect(r.stdout).to match(/Sample Application JSP Page/)
       end
     end


### PR DESCRIPTION
As per https://tomcat.apache.org/tomcat-8.0-doc/config/context.html it
is often useful to put pound signs in the warfile name, though curl
seems to interpret these as replacement patterns and I couldn't find any
way to escape them. wget doesn't care.

tomcat hasn't yet been released with archive, so this isn't a breaking
change.