### PR TITLE
[MODULES-5360] Adding fix to allow the proxy settings to be passed to archive resource

### DIFF
--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -53,5 +53,7 @@ define tomcat::install::source (
     allow_insecure => $allow_insecure,
     user           => $user,
     group          => $group,
+    proxy_server   => $proxy_server,
+    proxy_type     => $proxy_type,
   }
 }


### PR DESCRIPTION
It looks like a recent change to the module has moved away from using `staging` and now `archive` is being used. The defined type `tomcat::install::source` is called from within the defined type `tomcat::install` and both are correctly parameterised with two proxy variables, however the proxy variables are not passed to the `archive` resource within `tomcat::install::source`.