### PR TITLE
(MODULES-1545) Switch back to curl

### DIFF
--- a/manifests/war.pp
+++ b/manifests/war.pp
@@ -78,10 +78,9 @@ define tomcat::war(
     # https://tomcat.apache.org/tomcat-8.0-doc/config/context.html whereas curl
     # does not.
     archive { "tomcat::war ${name}":
-      extract  => false,
-      source   => $war_source,
-      path     => "${_deployment_path}/${_war_name}",
-      provider => 'wget',
+      extract => false,
+      source  => $war_source,
+      path    => "${_deployment_path}/${_war_name}",
     }
   }
 }


### PR DESCRIPTION
Curl only fails for context versions of 1, but works for all other
contexts. wget is not available on redhat platforms.