### PR TITLE
(maint) Remove differences for inside/outside jenkins

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -22,38 +22,22 @@ def latest_tomcat_tarball_url(version)
   end
 end
 
-if ENV['BUILD_ID'] # We're in our CI system and use internal resources
-  ARTIFACT_HOST = ENV['TOMCAT_ARTIFACT_HOST'] || 'http://int-resources.corp.puppetlabs.net/QA_resources/tomcat'
+latest7 = latest_tomcat_tarball_url('7')
+latest8 = latest_tomcat_tarball_url('8')
+latest9 = latest_tomcat_tarball_url('9')
 
-  TOMCAT7_RECENT_VERSION = ENV['TOMCAT7_RECENT_VERSION'] || 'latest7'
-  TOMCAT7_RECENT_SOURCE = "#{ARTIFACT_HOST}/apache-tomcat-#{TOMCAT7_RECENT_VERSION}.tar.gz"
-  TOMCAT8_RECENT_VERSION = ENV['TOMCAT8_RECENT_VERSION'] || 'latest8'
-  TOMCAT8_RECENT_SOURCE = "#{ARTIFACT_HOST}/apache-tomcat-#{TOMCAT8_RECENT_VERSION}.tar.gz"
-  TOMCAT9_RECENT_VERSION = ENV['TOMCAT9_RECENT_VERSION'] || 'latest9'
-  TOMCAT9_RECENT_SOURCE = "#{ARTIFACT_HOST}/apache-tomcat-#{TOMCAT9_RECENT_VERSION}.tar.gz"
-  TOMCAT_LEGACY_VERSION = ENV['TOMCAT_RECENT_VERSION'] || '7.0.78'
-  TOMCAT_LEGACY_SOURCE = "#{ARTIFACT_HOST}/apache-tomcat-#{TOMCAT_LEGACY_VERSION}.tar.gz"
-  SAMPLE_WAR = "#{ARTIFACT_HOST}/sample.war"
-
-else # We're outside the CI system and use default locations
-  require 'net/http'
-  latest7 = latest_tomcat_tarball_url('7')
-  latest8 = latest_tomcat_tarball_url('8')
-  latest9 = latest_tomcat_tarball_url('9')
-
-  TOMCAT7_RECENT_VERSION = ENV['TOMCAT7_RECENT_VERSION'] || latest7
-  TOMCAT7_RECENT_SOURCE = latest7
-  puts "TOMCAT7_RECENT_SOURCE is #{TOMCAT7_RECENT_SOURCE.inspect}"
-  TOMCAT8_RECENT_VERSION = ENV['TOMCAT8_RECENT_VERSION'] || latest8
-  TOMCAT8_RECENT_SOURCE = latest8
-  puts "TOMCAT8_RECENT_SOURCE is #{TOMCAT8_RECENT_SOURCE.inspect}"
-  TOMCAT9_RECENT_VERSION = ENV['TOMCAT9_RECENT_VERSION'] || latest9
-  TOMCAT9_RECENT_SOURCE = latest9
-  puts "TOMCAT9_RECENT_SOURCE is #{TOMCAT9_RECENT_SOURCE.inspect}"
-  TOMCAT_LEGACY_VERSION = ENV['TOMCAT_LEGACY_VERSION'] || '7.0.78'
-  TOMCAT_LEGACY_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-7/v#{TOMCAT_LEGACY_VERSION}/bin/apache-tomcat-#{TOMCAT_LEGACY_VERSION}.tar.gz"
-  SAMPLE_WAR = 'https://tomcat.apache.org/tomcat-9.0-doc/appdev/sample/sample.war'
-end
+TOMCAT7_RECENT_VERSION = ENV['TOMCAT7_RECENT_VERSION'] || latest7
+TOMCAT7_RECENT_SOURCE = latest7
+puts "TOMCAT7_RECENT_SOURCE is #{TOMCAT7_RECENT_SOURCE.inspect}"
+TOMCAT8_RECENT_VERSION = ENV['TOMCAT8_RECENT_VERSION'] || latest8
+TOMCAT8_RECENT_SOURCE = latest8
+puts "TOMCAT8_RECENT_SOURCE is #{TOMCAT8_RECENT_SOURCE.inspect}"
+TOMCAT9_RECENT_VERSION = ENV['TOMCAT9_RECENT_VERSION'] || latest9
+TOMCAT9_RECENT_SOURCE = latest9
+puts "TOMCAT9_RECENT_SOURCE is #{TOMCAT9_RECENT_SOURCE.inspect}"
+TOMCAT_LEGACY_VERSION = ENV['TOMCAT_LEGACY_VERSION'] || '7.0.78'
+TOMCAT_LEGACY_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-7/v#{TOMCAT_LEGACY_VERSION}/bin/apache-tomcat-#{TOMCAT_LEGACY_VERSION}.tar.gz"
+SAMPLE_WAR = 'https://tomcat.apache.org/tomcat-9.0-doc/appdev/sample/sample.war'
 
 
 UNSUPPORTED_PLATFORMS = ['windows','Solaris','Darwin']


### PR DESCRIPTION
In e9c247564b21391edd6cf7d2b907af50044f9924 the ability to download from
internal mirrors was added due to the code for downloading from external
mirrors being flaky. The external code has been made more stable, and
this makes testing internally not possible and/or more complicated, so
just remove it.