### PR TITLE
(maint) Retry failures instead of blind sleeps

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,8 @@
 ---
+Gemfile:
+  optional:
+    ':system-tests':
+      - gem: rspec-retry
 appveyor.yml:
   delete: true
 # only run a minimal subset of tests on travis, running all the tests can cause travis to timeout

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :system_tests do
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
+  gem "rspec-retry",                                                             :require => false
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/spec/acceptance/acceptance_1b_spec.rb
+++ b/spec/acceptance/acceptance_1b_spec.rb
@@ -117,14 +117,13 @@ describe 'Acceptance case one', :unless => stop_test do
       EOS
       apply_manifest(pp, :catch_failures => true)
       apply_manifest(pp, :catch_changes  => true)
-      shell('sleep 15')
     end
-    it 'Should be serving a page on port 80' do
+    it 'Should be serving a page on port 80', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:80/war_one/hello.jsp', :acceptable_exit_codes => 0) do |r|
         r.stdout.should match(/Sample Application JSP Page/)
       end
     end
-    it 'Should be serving a page on port 8080' do
+    it 'Should be serving a page on port 8080', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8080/war_one/hello.jsp', :acceptable_exit_codes => 0) do |r|
         r.stdout.should match(/Sample Application JSP Page/)
       end
@@ -154,9 +153,8 @@ describe 'Acceptance case one', :unless => stop_test do
       }
       EOS
       apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
-      shell('sleep 15')
     end
-    it 'Should not be serving a page on port 80' do
+    it 'Should not be serving a page on port 80', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:80/war_one/hello.jsp', :acceptable_exit_codes => 7)
     end
   end
@@ -184,9 +182,8 @@ describe 'Acceptance case one', :unless => stop_test do
       }
       EOS
       apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
-      shell('sleep 15')
     end
-    it 'Should be serving a page on port 80' do
+    it 'Should be serving a page on port 80', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:80/war_one/hello.jsp', :acceptable_exit_codes => 0) do |r|
         r.stdout.should match(/Sample Application JSP Page/)
       end
@@ -203,9 +200,8 @@ describe 'Acceptance case one', :unless => stop_test do
       }
       EOS
       apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
-      shell('sleep 15')
     end
-    it 'Should not have deployed the war' do
+    it 'Should not have deployed the war', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:80/war_one/hello.jsp', :acceptable_exit_codes => 0) do |r|
         r.stdout.should eq("")
       end
@@ -242,9 +238,8 @@ describe 'Acceptance case one', :unless => stop_test do
       }
       EOS
       apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
-      shell('sleep 15')
     end
-    it 'Should not be able to serve pages over port 80' do
+    it 'Should not be able to serve pages over port 80', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:80', :acceptable_exit_codes => 7)
     end
   end

--- a/spec/acceptance/acceptance_2b_spec.rb
+++ b/spec/acceptance/acceptance_2b_spec.rb
@@ -146,25 +146,24 @@ describe 'Two different installations with two instances each of Tomcat 7 in the
       EOS
       apply_manifest(pp, :catch_failures => true)
       apply_manifest(pp, :catch_changes => true)
-      shell('sleep 15')
     end
     #test the war
-    it 'tomcat7-first should have war deployed by default' do
+    it 'tomcat7-first should have war deployed by default', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8280/tomcat7/sample/hello.jsp', :acceptable_exit_codes => 0) do |r|
         expect(r.stdout).to match(/Sample Application JSP Page/)
       end
     end
-    it 'tomcat7-second should have war deployed by default' do
+    it 'tomcat7-second should have war deployed by default', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8281/tomcat7/sample/hello.jsp', :acceptable_exit_codes => 0) do |r|
         expect(r.stdout).to match(/Sample Application JSP Page/)
       end
     end
-    it 'tomcat7078-first should have war deployed by default' do
+    it 'tomcat7078-first should have war deployed by default', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8380/tomcat7078-sample/hello.jsp', :acceptable_exit_codes => 0) do |r|
         expect(r.stdout).to match(/Sample Application JSP Page/)
       end
     end
-    it 'tomcat7078-second should have war deployed by default' do
+    it 'tomcat7078-second should have war deployed by default', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8381/tomcat7078-sample/hello.jsp', :acceptable_exit_codes => 0) do |r|
         expect(r.stdout).to match(/Sample Application JSP Page/)
       end
@@ -196,18 +195,17 @@ describe 'Two different installations with two instances each of Tomcat 7 in the
       }
       EOS
       apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
-      shell('sleep 15')
     end
-    it 'tomcat7-first should not be serving a page on port 8280' do
+    it 'tomcat7-first should not be serving a page on port 8280', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8280', :acceptable_exit_codes => 7)
     end
-    it 'tomcat7-second should not be serving a page on port 8281' do
+    it 'tomcat7-second should not be serving a page on port 8281', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8281', :acceptable_exit_codes => 7)
     end
-    it 'tomcat7078-first should not be serving a page on port 8380' do
+    it 'tomcat7078-first should not be serving a page on port 8380', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8380', :acceptable_exit_codes => 7)
     end
-    it 'tomcat7078-second should not be serving a page on port 8381' do
+    it 'tomcat7078-second should not be serving a page on port 8381', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8381', :acceptable_exit_codes => 7)
     end
   end
@@ -239,14 +237,13 @@ describe 'Two different installations with two instances each of Tomcat 7 in the
       }
       EOS
       apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
-      shell('sleep 15')
     end
-    it 'tomcat7-first should not display message when war is not deployed' do
+    it 'tomcat7-first should not display message when war is not deployed', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8280/tomcat7-sample/hello.jsp') do |r|
         expect(r.stdout).to_not match(/Sample Application JSP Page/)
       end
     end
-    it 'tomcat7078-first should not display message when war is not deployed' do
+    it 'tomcat7078-first should not display message when war is not deployed', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8380/tomcat7078-sample/hello.jsp') do |r|
         expect(r.stdout).to_not match(/Sample Application JSP Page/)
       end
@@ -270,14 +267,13 @@ describe 'Two different installations with two instances each of Tomcat 7 in the
       }
       EOS
       apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
-      shell('sleep 15')
     end
-    it 'tomcat7 should be serving a war on port 8280' do
+    it 'tomcat7 should be serving a war on port 8280', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8280/tomcat7-sample/hello.jsp') do |r|
         expect(r.stdout).to match(/Sample Application JSP Page/)
       end
     end
-    it 'tomcat7078 should be serving a war on port 8380' do
+    it 'tomcat7078 should be serving a war on port 8380', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8380/tomcat7078-sample/hello.jsp') do |r|
         expect(r.stdout).to match(/Sample Application JSP Page/)
       end

--- a/spec/acceptance/acceptance_3b_spec.rb
+++ b/spec/acceptance/acceptance_3b_spec.rb
@@ -54,14 +54,13 @@ describe 'Tomcat Install source -defaults', docker: true, :unless => stop_test d
       EOS
       apply_manifest(pp, :catch_failures => true)
       apply_manifest(pp, :catch_changes  => true)
-      shell('sleep 15')
     end
-    it 'Should be serving a page on port 8180' do
+    it 'Should be serving a page on port 8180', :retry => 3, :retry_wait => 10 do
       shell('curl --retry 15 --retry-delay 4 localhost:8180') do |r|
         r.stdout.should eq("")
       end
     end
-    it 'Should be serving a JSP page from the war' do
+    it 'Should be serving a JSP page from the war', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8180/tomcat8-sample/hello.jsp') do |r|
         r.stdout.should match(/Sample Application JSP Page/)
       end
@@ -78,9 +77,8 @@ describe 'Tomcat Install source -defaults', docker: true, :unless => stop_test d
       }
       EOS
       apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
-      shell('sleep 15')
     end
-    it 'Should not be serving a page on port 8180' do
+    it 'Should not be serving a page on port 8180', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8180', :acceptable_exit_codes => 7)
     end
   end
@@ -95,9 +93,8 @@ describe 'Tomcat Install source -defaults', docker: true, :unless => stop_test d
       }
       EOS
       apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
-      shell('sleep 15')
     end
-    it 'Should be serving a page on port 8180' do
+    it 'Should be serving a page on port 8180', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8180') do |r|
         r.stdout.should eq("")
       end
@@ -114,9 +111,8 @@ describe 'Tomcat Install source -defaults', docker: true, :unless => stop_test d
       }
       EOS
       apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
-      shell('sleep 15')
     end
-    it 'Should not have deployed the war' do
+    it 'Should not have deployed the war', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8180/tomcat8-sample/hello.jsp', :acceptable_exit_codes => 0) do |r|
         r.stdout.should eq("")
       end
@@ -138,9 +134,8 @@ describe 'Tomcat Install source -defaults', docker: true, :unless => stop_test d
       }
       EOS
       apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
-      shell('sleep 15')
     end
-    it 'Should not be abble to serve pages over port 8180' do
+    it 'Should not be abble to serve pages over port 8180', :retry => 3, :retry_wait => 10 do
       shell('curl localhost:8180', :acceptable_exit_codes => 7)
     end
   end

--- a/spec/acceptance/acceptance_4b_spec.rb
+++ b/spec/acceptance/acceptance_4b_spec.rb
@@ -85,7 +85,6 @@ describe 'Use two realms within a configuration', docker: true, :unless => stop_
       }
       EOS
       apply_manifest(pp, :catch_failures => true, :acceptable_exit_codes => [0,2])
-      shell('sleep 15')
     end
     it 'Should contain two realms in config file' do
       shell('cat /opt/apache-tomcat40/conf/server.xml', :acceptable_exit_codes => 0) do |r|

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,6 +2,7 @@ require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
+require 'rspec/retry'
 
 run_puppet_install_helper
 install_ca_certs unless ENV['PUPPET_INSTALL_TYPE'] =~ /pe/i
@@ -46,6 +47,8 @@ UNSUPPORTED_PLATFORMS = ['windows','Solaris','Darwin']
 RSpec.configure do |c|
   c.filter_run :focus => true
   c.run_all_when_everything_filtered = true
+  c.verbose_retry = true
+  c.display_try_failure_messages = true
 
   # Readable test descriptions
   c.formatter = :documentation


### PR DESCRIPTION
The sleep 15s are too short on vmpooler for some reason. Rather than
making them longer, just retry the tests. tomcat takes a while to load
.war files into memory and serve them, and this is not puppet's problem.