### PR TITLE
Add ability to set status_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1707,6 +1707,14 @@ Valid options: a string.
 
 Default value: determined by the values of `use_init` and `use_jsvc`.
 
+##### `status_command`
+
+Designates a command to get the status of the service.
+
+Valid options: a string.
+
+Default value: determined by the values of `use_init` and `use_jsvc`.
+
 ##### `stop_command`
 
 Designates a command to stop the service.

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -25,12 +25,13 @@ describe 'tomcat::service', :type => :define do
     )
     }
   end
-  context 'set start/stop with jsvc' do
+  context 'set start/stop/status with jsvc' do
     let :params do
       {
-        :use_jsvc      => true,
-        :start_command => '/bin/true',
-        :stop_command  => '/bin/true',
+        :use_jsvc       => true,
+        :start_command  => '/bin/true',
+        :stop_command   => '/bin/true',
+        :status_command => '/bin/true',
       }
     end
     it { is_expected.to contain_service('tomcat-default').with(
@@ -39,6 +40,7 @@ describe 'tomcat::service', :type => :define do
       'ensure'     => 'running',
       'start'      => '/bin/true',
       'stop'       => '/bin/true',
+      'status'     => '/bin/true',
     )
     }
   end
@@ -114,11 +116,12 @@ describe 'tomcat::service', :type => :define do
     )
     }
   end
-  context "default, set start/stop" do
+  context "default, set start/stop/status" do
     let :params do
       {
-        :start_command => '/bin/true',
-        :stop_command  => '/bin/true',
+        :start_command  => '/bin/true',
+        :stop_command   => '/bin/true',
+        :status_command => '/bin/true',
       }
     end
     it { is_expected.to contain_service('tomcat-default').with(
@@ -127,6 +130,7 @@ describe 'tomcat::service', :type => :define do
       'ensure'     => 'running',
       'start'      => '/bin/true',
       'stop'       => '/bin/true',
+      'status'     => '/bin/true',
     )
     }
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,7 @@ begin
   require 'spec_helper_local'
 rescue LoadError
 end
+
+RSpec.configure do |config|
+  config.before(:all) {Facter.clear}
+end


### PR DESCRIPTION
The default status command wasn't working with the vendor's tomcat rpm, so added the ability to set a custom command similar to stop_command and start_command.

Also added a Facter.clear block to spec_helper, because my rake output was failing on too many fact resolutions.