### PR TITLE
Fixes Gemfile and avoid break in future module syncs.

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,7 +1,7 @@
 ---
 Gemfile:
   optional:
-    ':system-tests':
+    ':system_tests':
       - gem: rspec-retry
 appveyor.yml:
   delete: true

--- a/Gemfile
+++ b/Gemfile
@@ -60,9 +60,6 @@ group :system_tests do
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
-end
-
-group :system-tests do
   gem "rspec-retry", :require => false
 end
 


### PR DESCRIPTION
Currently the .sync file has a system-test group. It should have
system_test. This PR changes it and updates the Gemfile.
The changes will stop modulesync breaking this in the future.
  