### PR TITLE
Change puppet/archive version compatibility from 2.0.0 to 3.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 < 5.0.0"},
-    {"name":"puppet/archive","version_requirement":">= 1.0.0 < 2.0.0"}
+    {"name":"puppet/archive","version_requirement":">= 1.0.0 < 3.0.0"}
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
Change to manifest.json to raise the maximum version for puppet-archive module from <2.0.0 to <3.0.0 to be able to use latest version of puppet-archive module.