### PR TITLE
Fix failing curl command

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 < 5.0.0"},
-    {"name":"puppet/archive","version_requirement":">= 1.0.0 < 2.0.0"}
+    {"name":"puppet/archive","version_requirement":">= 1.0.0 < 3.0.0"}
   ],
   "operatingsystem_support": [
     {

--- a/spec/acceptance/acceptance_1b_spec.rb
+++ b/spec/acceptance/acceptance_1b_spec.rb
@@ -112,12 +112,12 @@ describe 'Acceptance case one', unless: stop_test do
       apply_manifest(pp, catch_changes: true)
     end
     it 'is serving a page on port 80', retry: 5, retry_wait: 10 do
-      shell('curl localhost:80/war_one/hello.jsp', acceptable_exit_codes: 0) do |r|
+      shell('curl --retry 5 --retry-delay 15 localhost:80/war_one/hello.jsp', acceptable_exit_codes: 0) do |r|
         r.stdout.should match(%r{Sample Application JSP Page})
       end
     end
     it 'is serving a page on port 8080', retry: 5, retry_wait: 10 do
-      shell('curl localhost:8080/war_one/hello.jsp', acceptable_exit_codes: 0) do |r|
+      shell('curl --retry 5 --retry-delay 15 localhost:8080/war_one/hello.jsp', acceptable_exit_codes: 0) do |r|
         r.stdout.should match(%r{Sample Application JSP Page})
       end
     end
@@ -148,7 +148,7 @@ describe 'Acceptance case one', unless: stop_test do
       apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
     it 'is not serving a page on port 80', retry: 5, retry_wait: 10 do
-      shell('curl localhost:80/war_one/hello.jsp', acceptable_exit_codes: 7)
+      shell('curl --retry 5 --retry-delay 15 localhost:80/war_one/hello.jsp', acceptable_exit_codes: 7)
     end
   end
 
@@ -177,7 +177,7 @@ describe 'Acceptance case one', unless: stop_test do
       apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
     it 'is serving a page on port 80', retry: 5, retry_wait: 10 do
-      shell('curl localhost:80/war_one/hello.jsp', acceptable_exit_codes: 0) do |r|
+      shell('curl --retry 5 --retry-delay 15 localhost:80/war_one/hello.jsp', acceptable_exit_codes: 0) do |r|
         r.stdout.should match(%r{Sample Application JSP Page})
       end
     end
@@ -232,7 +232,7 @@ describe 'Acceptance case one', unless: stop_test do
       apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
     it 'is not able to serve pages over port 80', retry: 5, retry_wait: 10 do
-      shell('curl localhost:80', acceptable_exit_codes: 7)
+      shell('curl --retry 5 --retry-delay 15 localhost:80', acceptable_exit_codes: 7)
     end
   end
 end

--- a/spec/acceptance/acceptance_2b_spec.rb
+++ b/spec/acceptance/acceptance_2b_spec.rb
@@ -155,22 +155,22 @@ describe 'Two different installations with two instances each of Tomcat 7 in the
     end
     # test the war
     it 'tomcat7-first should have war deployed by default', retry: 5, retry_wait: 10 do
-      shell('curl localhost:8280/tomcat7/sample/hello.jsp', acceptable_exit_codes: 0) do |r|
+      shell('curl --retry 5 --retry-delay 15 localhost:8280/tomcat7/sample/hello.jsp', acceptable_exit_codes: 0) do |r|
         expect(r.stdout).to match(%r{Sample Application JSP Page})
       end
     end
     it 'tomcat7-second should have war deployed by default', retry: 5, retry_wait: 10 do
-      shell('curl localhost:8281/tomcat7/sample/hello.jsp', acceptable_exit_codes: 0) do |r|
+      shell('curl --retry 5 --retry-delay 15 localhost:8281/tomcat7/sample/hello.jsp', acceptable_exit_codes: 0) do |r|
         expect(r.stdout).to match(%r{Sample Application JSP Page})
       end
     end
     it 'tomcat7078-first should have war deployed by default', retry: 5, retry_wait: 10 do
-      shell('curl localhost:8380/tomcat7078-sample/hello.jsp', acceptable_exit_codes: 0) do |r|
+      shell('curl --retry 5 --retry-delay 15 localhost:8380/tomcat7078-sample/hello.jsp', acceptable_exit_codes: 0) do |r|
         expect(r.stdout).to match(%r{Sample Application JSP Page})
       end
     end
     it 'tomcat7078-second should have war deployed by default', retry: 5, retry_wait: 10 do
-      shell('curl localhost:8381/tomcat7078-sample/hello.jsp', acceptable_exit_codes: 0) do |r|
+      shell('curl --retry 5 --retry-delay 15 localhost:8381/tomcat7078-sample/hello.jsp', acceptable_exit_codes: 0) do |r|
         expect(r.stdout).to match(%r{Sample Application JSP Page})
       end
     end
@@ -287,12 +287,12 @@ describe 'Two different installations with two instances each of Tomcat 7 in the
       apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
     it 'tomcat7 should be serving a war on port 8280', retry: 10, retry_wait: 10 do
-      shell('curl localhost:8280/tomcat7-sample/hello.jsp') do |r|
+      shell('curl --retry 5 --retry-delay 15 localhost:8280/tomcat7-sample/hello.jsp') do |r|
         expect(r.stdout).to match(%r{Sample Application JSP Page})
       end
     end
     it 'tomcat7078 should be serving a war on port 8380', retry: 10, retry_wait: 10 do
-      shell('curl localhost:8380/tomcat7078-sample/hello.jsp') do |r|
+      shell('curl --retry 5 --retry-delay 15 localhost:8380/tomcat7078-sample/hello.jsp') do |r|
         expect(r.stdout).to match(%r{Sample Application JSP Page})
       end
     end

--- a/spec/acceptance/acceptance_3b_spec.rb
+++ b/spec/acceptance/acceptance_3b_spec.rb
@@ -10,7 +10,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
   end
 
   before :all do
-    shell("curl -k -1 -o /tmp/sample.war '#{SAMPLE_WAR}'", acceptable_exit_codes: 0)
+    shell("curl --retry 5 --retry-delay 15 -k -o /tmp/sample.war '#{SAMPLE_WAR}'", acceptable_exit_codes: 0)
   end
 
   context 'Initial install Tomcat and verification' do
@@ -58,12 +58,12 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       apply_manifest(pp, catch_changes: true)
     end
     it 'is serving a page on port 8180', retry: 5, retry_wait: 10 do
-      shell('curl --retry 15 --retry-delay 4 localhost:8180') do |r|
+      shell('curl --retry 5 --retry-delay 15 localhost:8180') do |r|
         r.stdout.should eq('')
       end
     end
     it 'is serving a JSP page from the war', retry: 5, retry_wait: 10 do
-      shell('curl localhost:8180/tomcat8-sample/hello.jsp') do |r|
+      shell('curl --retry 5 --retry-delay 15 localhost:8180/tomcat8-sample/hello.jsp') do |r|
         r.stdout.should match(%r{Sample Application JSP Page})
       end
     end
@@ -97,7 +97,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
     it 'is serving a page on port 8180', retry: 5, retry_wait: 10 do
-      shell('curl localhost:8180') do |r|
+      shell('curl --retry 5 --retry-delay 15 localhost:8180') do |r|
         r.stdout.should eq('')
       end
     end
@@ -115,7 +115,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
     it 'does not have deployed the war', retry: 5, retry_wait: 10 do
-      shell('curl localhost:8180/tomcat8-sample/hello.jsp', acceptable_exit_codes: 0) do |r|
+      shell('curl --retry 5 --retry-delay 15 localhost:8180/tomcat8-sample/hello.jsp', acceptable_exit_codes: 0) do |r|
         r.stdout.should eq('')
       end
     end
@@ -137,7 +137,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
     it 'applies the manifest without error' do
       apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
-    it 'is not abble to serve pages over port 8180', retry: 5, retry_wait: 10 do
+    it 'is not able to serve pages over port 8180', retry: 5, retry_wait: 10 do
       shell('curl localhost:8180', acceptable_exit_codes: 7)
     end
   end

--- a/spec/acceptance/acceptance_4b_spec.rb
+++ b/spec/acceptance/acceptance_4b_spec.rb
@@ -10,7 +10,7 @@ describe 'Use two realms within a configuration', docker: true, unless: stop_tes
   end
 
   before :all do
-    shell("curl -k -1 -o /tmp/sample.war '#{SAMPLE_WAR}'", acceptable_exit_codes: 0)
+    shell("curl --retry 5 --retry-delay 15 -k -o /tmp/sample.war '#{SAMPLE_WAR}'", acceptable_exit_codes: 0)
   end
 
   context 'Initial install Tomcat and verification' do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -46,8 +46,9 @@ TOMCAT9_RECENT_VERSION = ENV['TOMCAT9_RECENT_VERSION'] || latest9
 TOMCAT9_RECENT_SOURCE = latest9
 puts "TOMCAT9_RECENT_SOURCE is #{TOMCAT9_RECENT_SOURCE.inspect}"
 TOMCAT_LEGACY_VERSION = ENV['TOMCAT_LEGACY_VERSION'] || '7.0.78'
+# Please note that these URLs are http and therefore insecure. To remedy this you can change them to https, although some additional work may be required to match the required protocols of the server.
 TOMCAT_LEGACY_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-7/v#{TOMCAT_LEGACY_VERSION}/bin/apache-tomcat-#{TOMCAT_LEGACY_VERSION}.tar.gz".freeze
-SAMPLE_WAR = 'https://tomcat.apache.org/tomcat-9.0-doc/appdev/sample/sample.war'.freeze
+SAMPLE_WAR = 'http://tomcat.apache.org/tomcat-9.0-doc/appdev/sample/sample.war'.freeze
 
 LATEST_DAEMON_8 = latest_daemon_version(TOMCAT8_RECENT_VERSION)
 


### PR DESCRIPTION
The servers where we find our .war file have changed the way they function, the addition of the -1 flag is needed to successfully download. As a result I've added the extra download_options and had to bump the archive dependancy.