### PR TITLE
(maint) - Update links in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,7 @@ This is a bugfix release.
 
 Initial release of the tomcat module.
 
-[2.3.0]: https://github.com/puppetlabs/puppetlabs-tomcat/compare/2.1.0...2.2.0
+[2.2.0]: https://github.com/puppetlabs/puppetlabs-tomcat/compare/2.1.0...2.2.0
+[2.1.0]: https://github.com/puppetlabs/puppetlabs-tomcat/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/puppetlabs/puppetlabs-tomcat/compare/1.7.0...2.0.0
 [1.7.0]: https://github.com/puppetlabs/puppetlabs-tomcat/compare/1.6.1...1.7.0


### PR DESCRIPTION
Currently 2.2.0 link is wrong and it is missing 2.1.0. Addressing the mistake and adding 2.1.0.