### PR TITLE
(MODULES-6626) fix the generated shell when using addto

### DIFF
--- a/manifests/setenv/entry.pp
+++ b/manifests/setenv/entry.pp
@@ -61,7 +61,7 @@ define tomcat::setenv::entry (
   }
 
   if $addto {
-    $_content = inline_template('<%= @_doexport %> <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char+"\n" %> ; <%= @_doexport %> <%= @addto %>="$<%= @addto %> $<%= @param %>"')
+    $_content = inline_template('<%= @_doexport %> <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char %> ; <%= @_doexport %> <%= @addto %>="$<%= @addto %> $<%= @param %>"')
   } else {
     $_content = inline_template('<%= @_doexport %> <%= @param %>=<%= @_quote_char %><%= Array(@value).join(" ") %><%= @_quote_char+"\n" %>')
   }


### PR DESCRIPTION
It is an error to start a line with a semicolon (IOW, use ; or \n but not
both).