### PR TITLE
adding wait_timeout var for init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1750,6 +1750,14 @@ Default value: `false`.
 
 The user of the jsvc process when `use_init => true`
 
+##### `wait_timeout`
+
+The wait timeout set in the jsvc init script when `use_init => true` and `use_jsvc => true`
+
+Valid options: Integer.
+
+Default value: `10`.
+
 #### tomcat::setenv::entry
 
 ##### `config_file`

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -25,6 +25,7 @@
 # @param stop_command The stop command to use for the service
 # @param status_command The status command to use for the service
 # @param user is the user of the jsvc process.
+# @param wait_timeout is the wait timeout set in the init script. Defaults to 10.
 define tomcat::service (
   $catalina_home                    = undef,
   $catalina_base                    = undef,
@@ -38,6 +39,7 @@ define tomcat::service (
   $stop_command                     = undef,
   $status_command                   = undef,
   $user                             = undef,
+  $wait_timeout                     = 10,
 ) {
   include ::tomcat
   $_user = pick($user, $::tomcat::user)

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -39,7 +39,7 @@ define tomcat::service (
   $stop_command                     = undef,
   $status_command                   = undef,
   $user                             = undef,
-  $wait_timeout                     = 10,
+  Integer $wait_timeout             = 10,
 ) {
   include ::tomcat
   $_user = pick($user, $::tomcat::user)

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -212,6 +212,19 @@ describe 'tomcat::service', type: :define do
       )
     }
   end
+  context 'jsvc true and init true with wait_timeoutl, expect init script contains wait_timeout' do
+    let :params do
+      {
+        use_jsvc: true,
+        use_init: true,
+        wait_timeout: 15,
+      }
+    end
+
+    it {
+      is_expected.to contain_file('/etc/init.d/tomcat-default').with_content(%r{^WAIT_TIMEOUT=15$})
+    }
+  end
   describe 'failing tests' do
     context 'bad use_jsvc' do
       let :params do

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -192,6 +192,26 @@ describe 'tomcat::service', type: :define do
     # so let's just make sure it compiles
     it { is_expected.to compile }
   end
+  context 'jsvc true and init true with wait_timeout' do
+    let :params do
+      {
+        use_jsvc: true,
+        use_init: true,
+        wait_timeout: 15,
+      }
+    end
+
+    it {
+      is_expected.to contain_service('tomcat-default').with(
+        'hasstatus' => true,
+        'hasrestart' => true,
+        'ensure' => 'running',
+        'start' => 'service tomcat-default start',
+        'stop' => 'service tomcat-default stop',
+        'status' => 'service tomcat-default status',
+      )
+    }
+  end
   describe 'failing tests' do
     context 'bad use_jsvc' do
       let :params do
@@ -237,6 +257,19 @@ describe 'tomcat::service', type: :define do
       end
 
       it { is_expected.to compile }
+    end
+    context 'bad wait_timeout' do
+      let :params do
+        {
+          wait_timeout: 'foo',
+        }
+      end
+
+      it do
+        expect {
+          catalogue
+        }.to raise_error(Puppet::Error, %r{Integer})
+      end
     end
   end
 end

--- a/templates/jsvc-init.erb
+++ b/templates/jsvc-init.erb
@@ -55,6 +55,7 @@ CATALINA_BASE=<%= @_catalina_base %>
 CATALINA_HOME=<%= @_catalina_home %>
 JAVA_HOME=<%= @java_home %>
 TOMCAT_USER=<%= @_user %>
+WAIT_TIMEOUT=<%= @wait_timeout %>
 
 # Use the maximum available, or set MAX_FD != -1 to use that
 test ".$MAX_FD" = . && MAX_FD="maximum"
@@ -150,7 +151,7 @@ do_start()
     -java-home "$JAVA_HOME" \
     -user "$TOMCAT_USER" \
     -pidfile "$CATALINA_PID" \
-    -wait 10 \
+    -wait $WAIT_TIMEOUT \
     -outfile "SYSLOG" \
     -errfile "SYSLOG" \
     -classpath "$CLASSPATH" \
@@ -219,7 +220,7 @@ case "$1" in
       -java-home "$JAVA_HOME" \
       -user "$TOMCAT_USER" \
       -pidfile "$CATALINA_PID" \
-      -wait 10 \
+      -wait $WAIT_TIMEOUT \
       -nodetach \
       -outfile "&1" \
       -errfile "&2" \


### PR DESCRIPTION
Adding a wait timeout var to allow for a greater wait period, this is to solve an issue we are having with a war needing 25+ seconds to start. The existing value of 10 causes an exit 1 code on service start in our case.