### PR TITLE
add show diff to all augeas calls

### DIFF
--- a/manifests/config/context.pp
+++ b/manifests/config/context.pp
@@ -2,9 +2,12 @@
 #
 # @param catalina_base
 #   Specifies the root of the Tomcat installation.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::context (
-  $catalina_base = undef,
+  $catalina_base     = undef,
+  Boolean $show_diff = true,
 ) {
   include ::tomcat
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
@@ -20,9 +23,11 @@ define tomcat::config::context (
 
   if ! empty($changes) {
     augeas { "context-${_catalina_base}":
-      lens    => 'Xml.lns',
-      incl    => "${_catalina_base}/conf/context.xml",
-      changes => $changes,
+      lens      => 'Xml.lns',
+      incl      => "${_catalina_base}/conf/context.xml",
+      changes   => $changes,
+      show_diff => $show_diff,
+
     }
   }
 }

--- a/manifests/config/context/environment.pp
+++ b/manifests/config/context/environment.pp
@@ -20,6 +20,8 @@
 #   Specifies any additional attributes to add to the Environment. Should be a hash of the format 'attribute' => 'value'.
 # @param attributes_to_remove
 #   Specifies an array of attributes to remove from the element. Valid options: an array of strings.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::context::environment (
   Enum['present','absent'] $ensure    = 'present',
@@ -31,6 +33,7 @@ define tomcat::config::context::environment (
   Optional[Boolean] $override         = undef,
   Hash $additional_attributes         = {},
   Array $attributes_to_remove         = [],
+  Boolean $show_diff                  = true,
 ) {
   if versioncmp($::augeasversion, '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
@@ -90,8 +93,9 @@ define tomcat::config::context::environment (
   }
 
   augeas { "context-${catalina_base}-environment-${name}":
-    lens    => 'Xml.lns',
-    incl    => "${catalina_base}/conf/context.xml",
-    changes => $changes,
+    lens      => 'Xml.lns',
+    incl      => "${catalina_base}/conf/context.xml",
+    changes   => $changes,
+    show_diff => $show_diff,
   }
 }

--- a/manifests/config/context/manager.pp
+++ b/manifests/config/context/manager.pp
@@ -12,6 +12,8 @@
 #   Specifies any additional attributes to add to the Manager. Should be a hash of the format 'attribute' => 'value'. Optional
 # @param attributes_to_remove
 #   Specifies an array of attributes to remove from the element. Valid options: an array of strings. `[]`.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::context::manager (
   Enum['present','absent'] $ensure = 'present',
@@ -19,6 +21,7 @@ define tomcat::config::context::manager (
   $manager_classname               = $name,
   Hash $additional_attributes      = {},
   Array $attributes_to_remove      = [],
+  Boolean $show_diff               = true,
 ) {
   if versioncmp($::augeasversion, '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
@@ -59,8 +62,9 @@ define tomcat::config::context::manager (
   }
 
   augeas { "context-${catalina_base}-manager-${name}":
-    lens    => 'Xml.lns',
-    incl    => "${catalina_base}/conf/context.xml",
-    changes => $changes,
+    lens      => 'Xml.lns',
+    incl      => "${catalina_base}/conf/context.xml",
+    changes   => $changes,
+    show_diff => $show_diff,
   }
 }

--- a/manifests/config/context/resource.pp
+++ b/manifests/config/context/resource.pp
@@ -14,6 +14,8 @@
 #   Specifies any additional attributes to add to the Valve. Should be a hash of the format 'attribute' => 'value'. Optional
 # @param attributes_to_remove
 #   Specifies an array of attributes to remove from the element. Valid options: an array of strings. `[]`.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::context::resource (
   Enum['present','absent'] $ensure = 'present',
@@ -22,6 +24,7 @@ define tomcat::config::context::resource (
   $catalina_base                   = $::tomcat::catalina_home,
   Hash $additional_attributes      = {},
   Array $attributes_to_remove      = [],
+  Boolean $show_diff               = true,
 ) {
   if versioncmp($::augeasversion, '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
@@ -67,8 +70,9 @@ define tomcat::config::context::resource (
   }
 
   augeas { "context-${catalina_base}-resource-${name}":
-    lens    => 'Xml.lns',
-    incl    => "${catalina_base}/conf/context.xml",
-    changes => $changes,
+    lens      => 'Xml.lns',
+    incl      => "${catalina_base}/conf/context.xml",
+    changes   => $changes,
+    show_diff => $show_diff,
   }
 }

--- a/manifests/config/context/resourcelink.pp
+++ b/manifests/config/context/resourcelink.pp
@@ -14,6 +14,8 @@
 #   Specifies any additional attributes to add to the Valve. Should be a hash of the format 'attribute' => 'value'. Optional
 # @param attributes_to_remove
 #   Specifies an array of attributes to remove from the element. Valid options: an array of strings. `[]`.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::context::resourcelink (
   Enum['present','absent'] $ensure = 'present',
@@ -22,6 +24,7 @@ define tomcat::config::context::resourcelink (
   $resourcelink_type               = undef,
   Hash $additional_attributes      = {},
   Array $attributes_to_remove      = [],
+  Boolean $show_diff               = true,
 ) {
   if versioncmp($::augeasversion, '1.0.0') < 0 {
     fail('Context configurations require Augeas >= 1.0.0')
@@ -59,8 +62,9 @@ define tomcat::config::context::resourcelink (
   }
 
   augeas { "context-${catalina_base}-resourcelink-${name}":
-    lens    => 'Xml.lns',
-    incl    => "${catalina_base}/conf/context.xml",
-    changes => $augeaschanges,
+    lens      => 'Xml.lns',
+    incl      => "${catalina_base}/conf/context.xml",
+    changes   => $augeaschanges,
+    show_diff => $show_diff,
   }
 }

--- a/manifests/config/context/valve.pp
+++ b/manifests/config/context/valve.pp
@@ -14,6 +14,8 @@
 #   Specifies any further attributes to add to the Valve. Valid options: a hash of '< attribute >' => '< value >' pairs. `{}`.
 # @param attributes_to_remove
 #   Specifies an array of attributes to remove from the element. Valid options: an array of strings. `[]`.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::context::valve (
   Enum['present','absent'] $ensure = 'present',
@@ -22,6 +24,7 @@ define tomcat::config::context::valve (
   $catalina_base                   = $::tomcat::catalina_home,
   Hash $additional_attributes      = {},
   Array $attributes_to_remove      = [],
+  Boolean $show_diff               = true,
 ) {
   if versioncmp($::augeasversion, '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
@@ -67,8 +70,9 @@ define tomcat::config::context::valve (
   }
 
   augeas { "context-${catalina_base}-valve-${name}":
-    lens    => 'Xml.lns',
-    incl    => "${catalina_base}/conf/context.xml",
-    changes => $changes,
+    lens      => 'Xml.lns',
+    incl      => "${catalina_base}/conf/context.xml",
+    changes   => $changes,
+    show_diff => $show_diff,
   }
 }

--- a/manifests/config/server.pp
+++ b/manifests/config/server.pp
@@ -16,6 +16,8 @@
 #   Designates a command that shuts down Tomcat when the command is received through the specified address and port. Maps to the [shutdown XML attribute](http://tomcat.apache.org/tomcat-8.0-doc/config/server.html#Common_Attributes). Valid options: a string.
 # @param server_config
 #   Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server (
   $catalina_base                              = undef,
@@ -26,6 +28,7 @@ define tomcat::config::server (
   $port                                       = undef,
   $shutdown                                   = undef,
   $server_config                              = undef,
+  Boolean $show_diff                          = true,
 ) {
   include ::tomcat
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
@@ -73,9 +76,10 @@ define tomcat::config::server (
 
   if ! empty($changes) {
     augeas { "server-${_catalina_base}":
-      lens    => 'Xml.lns',
-      incl    => $_server_config,
-      changes => $changes,
+      lens      => 'Xml.lns',
+      incl      => $_server_config,
+      changes   => $changes,
+      show_diff => $show_diff,
     }
   }
 }

--- a/manifests/config/server/connector.pp
+++ b/manifests/config/server/connector.pp
@@ -20,6 +20,8 @@
 #   Specifies whether to purge any unmanaged Connector elements that match defined protocol but have a different port from the configuration file.
 # @param server_config
 #   Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::connector (
   $catalina_base                             = undef,
@@ -31,6 +33,7 @@ define tomcat::config::server::connector (
   Array $attributes_to_remove                = [],
   Optional[Boolean] $purge_connectors        = undef,
   $server_config                             = undef,
+  Boolean $show_diff                         = true,
 ) {
   include ::tomcat
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
@@ -98,8 +101,9 @@ define tomcat::config::server::connector (
   }
 
   augeas { "server-${_catalina_base}-${parent_service}-connector-${port}":
-    lens    => 'Xml.lns',
-    incl    => $_server_config,
-    changes => $changes,
+    lens      => 'Xml.lns',
+    incl      => $_server_config,
+    changes   => $changes,
+    show_diff => $show_diff,
   }
 }

--- a/manifests/config/server/context.pp
+++ b/manifests/config/server/context.pp
@@ -18,6 +18,8 @@
 #   Specifies an array of attributes to remove from the element. Valid options: an array of strings.
 # @param server_config
 #   Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::context (
   $catalina_base                           = undef,
@@ -29,6 +31,7 @@ define tomcat::config::server::context (
   Hash $additional_attributes              = {},
   Array $attributes_to_remove              = [],
   $server_config                           = undef,
+  Boolean $show_diff                       = true,
 ) {
   include ::tomcat
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
@@ -97,8 +100,9 @@ define tomcat::config::server::context (
   }
 
   augeas { "${_catalina_base}-${_parent_service}-${_parent_engine}-${parent_host}-context-${name}":
-    lens    => 'Xml.lns',
-    incl    => $_server_config,
-    changes => $augeaschanges,
+    lens      => 'Xml.lns',
+    incl      => $_server_config,
+    changes   => $augeaschanges,
+    show_diff => $show_diff,
   }
 }

--- a/manifests/config/server/engine.pp
+++ b/manifests/config/server/engine.pp
@@ -26,6 +26,8 @@
 #   Specifies whether the [startStopThreads XML attribute](http://tomcat.apache.org/tomcat-8.0-doc/config/engine.html#Common_Attributes) should exist in the configuration file.
 # @param server_config
 #   Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::engine (
   $default_host,
@@ -41,6 +43,7 @@ define tomcat::config::server::engine (
   $start_stop_threads                                         = undef,
   Enum['present','absent'] $start_stop_threads_ensure         = 'present',
   $server_config                                              = undef,
+  Boolean $show_diff                                          = true,
 ) {
   include ::tomcat
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
@@ -109,8 +112,9 @@ define tomcat::config::server::engine (
   ])
 
   augeas { "${_catalina_base}-${parent_service}-engine":
-    lens    => 'Xml.lns',
-    incl    => $_server_config,
-    changes => $changes,
+    lens      => 'Xml.lns',
+    incl      => $_server_config,
+    changes   => $changes,
+    show_diff => $show_diff,
   }
 }

--- a/manifests/config/server/globalnamingresource.pp
+++ b/manifests/config/server/globalnamingresource.pp
@@ -14,6 +14,8 @@
 #   Specifies an array of attributes to remove from the element. Valid options: an array of strings.
 # @param server_config
 #   Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::globalnamingresource (
   $catalina_base                   = $::tomcat::catalina_home,
@@ -23,6 +25,7 @@ define tomcat::config::server::globalnamingresource (
   Hash $additional_attributes      = {},
   Array $attributes_to_remove      = [],
   $server_config                   = undef,
+  Boolean $show_diff               = true,
 ) {
   if versioncmp($::augeasversion, '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
@@ -69,16 +72,18 @@ define tomcat::config::server::globalnamingresource (
     # t:config::context::resource and others instead of an additional augeas
     # resource
     augeas { "server-${catalina_base}-globalresource-${name}-definition":
-      lens    => 'Xml.lns',
-      incl    => $_server_config,
-      changes => "set ${base_path}/#attribute/name '${_resource_name}'",
-      before  => Augeas["server-${catalina_base}-globalresource-${name}"],
+      lens      => 'Xml.lns',
+      incl      => $_server_config,
+      changes   => "set ${base_path}/#attribute/name '${_resource_name}'",
+      before    => Augeas["server-${catalina_base}-globalresource-${name}"],
+      show_diff => $show_diff,
     }
   }
 
   augeas { "server-${catalina_base}-globalresource-${name}":
-    lens    => 'Xml.lns',
-    incl    => $_server_config,
-    changes => $changes,
+    lens      => 'Xml.lns',
+    incl      => $_server_config,
+    changes   => $changes,
+    show_diff => $show_diff,
   }
 }

--- a/manifests/config/server/host.pp
+++ b/manifests/config/server/host.pp
@@ -18,6 +18,8 @@
 #   Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
 # @param aliases
 #   Optional array that specifies the list of [Host Name Aliases](http://tomcat.apache.org/tomcat-8.0-doc/config/host.html#Host_Name_Aliases) for this particular Host.  If omitted, any currently-defined Aliases will not be altered.  If present, the list Aliases  will be set to exactly match the contents of this array.  Thus, for example, an empty array can be used to explicitly force there to be no Aliases for the Host.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::host (
   $app_base                                     = undef,
@@ -29,6 +31,7 @@ define tomcat::config::server::host (
   Array $attributes_to_remove                   = [],
   Optional[String] $server_config               = undef,
   Optional[Array] $aliases                      = undef,
+  Boolean $show_diff                            = true,
 ) {
   include ::tomcat
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
@@ -92,8 +95,9 @@ define tomcat::config::server::host (
   }
 
   augeas { "${_catalina_base}-${parent_service}-host-${name}":
-    lens    => 'Xml.lns',
-    incl    => $_server_config,
-    changes => $changes,
+    lens      => 'Xml.lns',
+    incl      => $_server_config,
+    changes   => $changes,
+    show_diff => $show_diff,
   }
 }

--- a/manifests/config/server/listener.pp
+++ b/manifests/config/server/listener.pp
@@ -18,6 +18,8 @@
 #   Specifies an array of attributes to remove from the element. Valid options: an array of strings.
 # @param server_config
 #   Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::listener (
   $catalina_base                            = $::tomcat::catalina_home,
@@ -29,6 +31,7 @@ define tomcat::config::server::listener (
   Hash $additional_attributes               = {},
   Array $attributes_to_remove               = [],
   $server_config                            = undef,
+  Boolean $show_diff                        = true,
 ) {
   if versioncmp($::augeasversion, '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
@@ -89,8 +92,9 @@ define tomcat::config::server::listener (
   }
 
   augeas { "${catalina_base}-${_parent_service}-${parent_engine}-${parent_host}-listener-${name}":
-    lens    => 'Xml.lns',
-    incl    => $_server_config,
-    changes => $augeaschanges,
+    lens      => 'Xml.lns',
+    incl      => $_server_config,
+    changes   => $augeaschanges,
+    show_diff => $show_diff,
   }
 }

--- a/manifests/config/server/realm.pp
+++ b/manifests/config/server/realm.pp
@@ -24,6 +24,8 @@
 #   Specifies whether to purge any unmanaged Realm elements from the configuration file.
 # @param server_config
 #   Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::realm (
   $catalina_base                                          = undef,
@@ -37,6 +39,7 @@ define tomcat::config::server::realm (
   Array $attributes_to_remove                             = [],
   Optional[Boolean] $purge_realms                         = undef,
   $server_config                                          = undef,
+  Boolean $show_diff                                      = true,
 ) {
   include ::tomcat
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
@@ -122,9 +125,10 @@ define tomcat::config::server::realm (
   }
 
   augeas { "${_catalina_base}-${parent_service}-${parent_engine}-${parent_host}-${parent_realm}-realm-${name}":
-    lens    => 'Xml.lns',
-    incl    => $_server_config,
-    changes => $changes,
+    lens      => 'Xml.lns',
+    incl      => $_server_config,
+    changes   => $changes,
+    show_diff => $show_diff,
   }
 
 }

--- a/manifests/config/server/service.pp
+++ b/manifests/config/server/service.pp
@@ -10,6 +10,8 @@
 #   Specifies whether the [Service element](http://tomcat.apache.org/tomcat-8.0-doc/config/service.html#Introduction) should exist in the configuration file.
 # @param server_config
 #   Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::service (
   $catalina_base                              = undef,
@@ -17,6 +19,7 @@ define tomcat::config::server::service (
   Enum['present','absent'] $class_name_ensure = 'present',
   Enum['present','absent'] $service_ensure    = 'present',
   $server_config                              = undef,
+  Boolean $show_diff                          = true,
 ) {
   include ::tomcat
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
@@ -48,9 +51,10 @@ define tomcat::config::server::service (
 
   if ! empty($changes) {
     augeas { "server-${_catalina_base}-service-${name}":
-      lens    => 'Xml.lns',
-      incl    => $_server_config,
-      changes => $changes,
+      lens      => 'Xml.lns',
+      incl      => $_server_config,
+      changes   => $changes,
+      show_diff => $show_diff,
     }
   }
 }

--- a/manifests/config/server/tomcat_users.pp
+++ b/manifests/config/server/tomcat_users.pp
@@ -20,6 +20,8 @@
 #   Specifies a password for user elements. Valid options: a string.
 # @param roles
 #   Specifies one or more roles. Only valid if `element` is set to 'role' or 'user'. Valid options: an array of strings.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::tomcat_users (
   $catalina_base                   = $::tomcat::catalina_home,
@@ -32,6 +34,7 @@ define tomcat::config::server::tomcat_users (
   $group                           = undef,
   $password                        = undef,
   Array $roles                     = [],
+  Boolean $show_diff               = true,
 ) {
 
   if versioncmp($::augeasversion, '1.0.0') < 0 {
@@ -98,9 +101,10 @@ define tomcat::config::server::tomcat_users (
   $changes = delete_undef_values([$remove_entry, $add_entry, $add_password, $add_roles])
 
   augeas { "${catalina_base}-tomcat_users-${element}-${_element_name}-${name}":
-    lens    => 'Xml.lns',
-    incl    => $_file,
-    changes => $changes,
+    lens      => 'Xml.lns',
+    incl      => $_file,
+    changes   => $changes,
+    show_diff => $show_diff,
   }
 
 }

--- a/manifests/config/server/valve.pp
+++ b/manifests/config/server/valve.pp
@@ -18,6 +18,8 @@
 #   Specifies an array of attributes to remove from the element. Valid options: an array of strings.
 # @param server_config
 #   Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::valve (
   $catalina_base                         = undef,
@@ -29,6 +31,7 @@ define tomcat::config::server::valve (
   Hash $additional_attributes            = {},
   Array $attributes_to_remove            = [],
   $server_config                         = undef,
+  Boolean $show_diff                     = true,
 ) {
   include ::tomcat
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
@@ -81,8 +84,9 @@ define tomcat::config::server::valve (
   }
 
   augeas { "${_catalina_base}-${parent_service}-${parent_host}-valve-${name}":
-    lens    => 'Xml.lns',
-    incl    => $_server_config,
-    changes => $changes,
+    lens      => 'Xml.lns',
+    incl      => $_server_config,
+    changes   => $changes,
+    show_diff => $show_diff,
   }
 }


### PR DESCRIPTION
I found after a tomcat::config::server::globalnamingresource the augeas use the default values for show_diff this caused the password to be displayed in various log files. 

Please consider my pull request to allow to set show_diff to false. 