### PR TITLE
Improve consistency of ensurable resources

### DIFF
--- a/manifests/config/context/environment.pp
+++ b/manifests/config/context/environment.pp
@@ -41,7 +41,7 @@ define tomcat::config::context::environment (
 
   $base_path = "Context/Environment[#attribute/name='${environment_name}']"
 
-  if $ensure =~ /^(absent|false)$/ {
+  if $ensure == 'absent' {
     $changes = "rm ${base_path}"
   } else {
     if empty($type) {

--- a/manifests/config/context/manager.pp
+++ b/manifests/config/context/manager.pp
@@ -35,7 +35,7 @@ define tomcat::config::context::manager (
 
   $base_path = "Context/Manager[#attribute/className='${_manager_classname}']"
 
-  if $ensure =~ /^(absent|false)$/ {
+  if $ensure == 'absent' {
     $changes = "rm ${base_path}"
   } else {
     $set_name = "set ${base_path}/#attribute/className '${_manager_classname}'"

--- a/manifests/config/context/parameter.pp
+++ b/manifests/config/context/parameter.pp
@@ -16,7 +16,7 @@
 #
 define tomcat::config::context::parameter (
   Optional[String]                            $value          = undef,
-  Variant[Enum['present', 'absent'], Boolean] $ensure         = 'present',
+  Enum['present', 'absent']                   $ensure         = 'present',
   Pattern[/^(\/[^\/ ]*)+\/?$/]                $catalina_base  = $::tomcat::catalina_home,
   String                                      $parameter_name = $name,
   Optional[String]                            $description    = undef,
@@ -28,7 +28,7 @@ define tomcat::config::context::parameter (
 
   $base_path = "Context/Parameter[#attribute/name='${parameter_name}']"
 
-  if $ensure =~ /^(absent|false)$/ {
+  if $ensure == 'absent' {
     $changes = "rm ${base_path}"
   }
   else {

--- a/manifests/config/context/resource.pp
+++ b/manifests/config/context/resource.pp
@@ -38,7 +38,7 @@ define tomcat::config::context::resource (
 
   $base_path = "Context/Resource[#attribute/name='${_resource_name}']"
 
-  if $ensure =~ /^(absent|false)$/ {
+  if $ensure == 'absent' {
     $changes = "rm ${base_path}"
   } else {
     # (MODULES-3353) does this need to be quoted?

--- a/manifests/config/context/resourcelink.pp
+++ b/manifests/config/context/resourcelink.pp
@@ -32,7 +32,7 @@ define tomcat::config::context::resourcelink (
 
   $base_path = "Context/ResourceLink[#attribute/name='${resourcelink_name}']"
 
-  if $ensure =~ /^(absent|false)$/ {
+  if $ensure == 'absent' {
     $augeaschanges = "rm ${base_path}"
   } else {
     $set_name = "set ${base_path}/#attribute/name ${resourcelink_name}"

--- a/manifests/config/context/valve.pp
+++ b/manifests/config/context/valve.pp
@@ -38,7 +38,7 @@ define tomcat::config::context::valve (
 
   $base_path = "Context/Valve[#attribute/name='${_resource_name}']"
 
-  if $ensure =~ /^(absent|false)$/ {
+  if $ensure == 'absent' {
     $changes = "rm ${base_path}"
   } else {
     # (MODULES-3353) does this need to be quoted?

--- a/manifests/config/server/connector.pp
+++ b/manifests/config/server/connector.pp
@@ -55,7 +55,7 @@ define tomcat::config::server::connector (
     $__purge_connectors = undef
   }
 
-  if $_purge_connectors and ($connector_ensure =~ /^(absent|false)$/) {
+  if $_purge_connectors and ($connector_ensure == 'absent') {
     fail('$connector_ensure must be set to \'true\' or \'present\' to use $purge_connectors')
   }
 
@@ -65,7 +65,7 @@ define tomcat::config::server::connector (
     $_server_config = "${_catalina_base}/conf/server.xml"
   }
 
-  if $connector_ensure =~ /^(absent|false)$/ {
+  if $connector_ensure == 'absent' {
     if ! $port {
       $base_path = "${path}/Connector[#attribute/protocol='${protocol}']"
     } else {
@@ -74,7 +74,7 @@ define tomcat::config::server::connector (
     $changes = "rm ${base_path}"
   } else {
     if ! $port {
-      fail('$port must be specified unless $connector_ensure is set to \'absent\' or \'false\'')
+      fail('$port must be specified unless $connector_ensure is set to \'absent\'')
     }
 
     $base_path = "${path}/Connector[#attribute/port='${port}']"

--- a/manifests/config/server/context.pp
+++ b/manifests/config/server/context.pp
@@ -79,7 +79,7 @@ define tomcat::config::server::context (
   }
   # lint:endignore
 
-  if $context_ensure =~ /^(absent|false)$/ {
+  if $context_ensure == 'absent' {
     $augeaschanges = "rm ${path}"
   } else {
     $context = "set ${path}/#attribute/docBase ${_doc_base}"

--- a/manifests/config/server/engine.pp
+++ b/manifests/config/server/engine.pp
@@ -64,7 +64,7 @@ define tomcat::config::server::engine (
   $_name_change = "set ${base_path}/#attribute/name ${_name}"
   $_default_host = "set ${base_path}/#attribute/defaultHost ${default_host}"
 
-  if $background_processor_delay_ensure =~ /^(absent|false)$/ {
+  if $background_processor_delay_ensure == 'absent' {
     $_background_processor_delay = "rm ${base_path}/#attribute/backgroundProcessorDelay"
   } elsif $background_processor_delay {
     $_background_processor_delay = "set ${base_path}/#attribute/backgroundProcessorDelay ${background_processor_delay}"
@@ -72,7 +72,7 @@ define tomcat::config::server::engine (
     $_background_processor_delay = undef
   }
 
-  if $class_name_ensure =~ /^(absent|false)$/ {
+  if $class_name_ensure == 'absent' {
     $_class_name = "rm ${base_path}/#attribute/className"
   } elsif $class_name {
     $_class_name = "set ${base_path}/#attribute/className ${class_name}"
@@ -80,7 +80,7 @@ define tomcat::config::server::engine (
     $_class_name = undef
   }
 
-  if $jvm_route_ensure =~ /^(absent|false)$/ {
+  if $jvm_route_ensure == 'absent' {
     $_jvm_route = "rm ${base_path}/#attribute/jvmRoute"
   } elsif $jvm_route {
     $_jvm_route = "set ${base_path}/#attribute/jvmRoute ${jvm_route}"
@@ -88,7 +88,7 @@ define tomcat::config::server::engine (
     $_jvm_route = undef
   }
 
-  if $start_stop_threads_ensure =~ /^(absent|false)$/ {
+  if $start_stop_threads_ensure == 'absent' {
     $_start_stop_threads = "rm ${base_path}/#attribute/startStopThreads"
   } elsif $start_stop_threads {
     $_start_stop_threads = "set ${base_path}/#attribute/startStopThreads ${start_stop_threads}"

--- a/manifests/config/server/globalnamingresource.pp
+++ b/manifests/config/server/globalnamingresource.pp
@@ -49,7 +49,7 @@ define tomcat::config::server::globalnamingresource (
     $_server_config = "${catalina_base}/conf/server.xml"
   }
 
-  if $ensure =~ /^(absent|false)$/ {
+  if $ensure == 'absent' {
     $changes = "rm ${base_path}"
   } else {
     if ! empty($additional_attributes) {

--- a/manifests/config/server/listener.pp
+++ b/manifests/config/server/listener.pp
@@ -71,7 +71,7 @@ define tomcat::config::server::listener (
     $_server_config = "${catalina_base}/conf/server.xml"
   }
 
-  if $listener_ensure =~ /^(absent|false)$/ {
+  if $listener_ensure == 'absent' {
     $augeaschanges = "rm ${path}"
   } else {
     $listener = "set ${path}/#attribute/className ${_class_name}"

--- a/manifests/config/server/realm.pp
+++ b/manifests/config/server/realm.pp
@@ -30,7 +30,7 @@
 define tomcat::config::server::realm (
   $catalina_base                                          = undef,
   $class_name                                             = $name,
-  Variant[Enum['present','absent'],Boolean] $realm_ensure = 'present',
+  Enum['present','absent'] $realm_ensure                  = 'present',
   $parent_service                                         = 'Catalina',
   $parent_engine                                          = 'Catalina',
   $parent_host                                            = undef,
@@ -50,7 +50,7 @@ define tomcat::config::server::realm (
     fail('Server configurations require Augeas >= 1.0.0')
   }
 
-  if $_purge_realms and ($realm_ensure =~ /^(absent|false)$/) {
+  if $_purge_realms and ($realm_ensure == 'absent') {
     fail('$realm_ensure must be set to \'present\' to use $purge_realms')
   }
 
@@ -96,7 +96,7 @@ define tomcat::config::server::realm (
   # match.
   $path_expression = "#attribute/puppetName='${name}' or (count(#attribute/puppetName)=0 and #attribute/className='${class_name}')"
 
-  if $realm_ensure =~ /^(absent|false)$/ {
+  if $realm_ensure == 'absent' {
     $changes = "rm ${path}[${path_expression}]"
   } else {
 

--- a/manifests/config/server/service.pp
+++ b/manifests/config/server/service.pp
@@ -35,10 +35,10 @@ define tomcat::config::server::service (
     $_server_config = "${_catalina_base}/conf/server.xml"
   }
 
-  if $service_ensure =~ /^(absent|false)$/ {
+  if $service_ensure == 'absent' {
     $changes = "rm Server/Service[#attribute/name='${name}']"
   } else {
-    if $class_name_ensure =~ /^(absent|false)$/ {
+    if $class_name_ensure == 'absent' {
       $_class_name = "rm Server/Service[#attribute/name='${name}']/#attribute/className"
     } elsif $class_name {
       $_class_name = "set Server/Service[#attribute/name='${name}']/#attribute/className ${class_name}"

--- a/manifests/config/server/tomcat_users.pp
+++ b/manifests/config/server/tomcat_users.pp
@@ -81,7 +81,7 @@ define tomcat::config::server::tomcat_users (
 
   $path = "tomcat-users/${element}[#attribute/${element_identifier}='${_element_name}']"
 
-  if $ensure =~ /^(absent|false)$/ {
+  if $ensure == 'absent' {
     $add_entry = undef
     $remove_entry = "rm ${path}"
     $add_password = undef

--- a/manifests/config/server/valve.pp
+++ b/manifests/config/server/valve.pp
@@ -65,7 +65,7 @@ define tomcat::config::server::valve (
     $_server_config = "${_catalina_base}/conf/server.xml"
   }
 
-  if $valve_ensure =~ /^(absent|false)$/ {
+  if $valve_ensure == 'absent' {
     $changes = "rm ${base_path}"
   } else {
     $_class_name_change = "set ${base_path}/#attribute/className ${_class_name}"

--- a/manifests/war.pp
+++ b/manifests/war.pp
@@ -62,7 +62,7 @@ define tomcat::war(
     $_deployment_path = "${_catalina_base}/${_app_base}"
   }
 
-  if $war_ensure =~ /^(absent|false)$/ {
+  if $war_ensure == 'absent' {
     file { "${_deployment_path}/${_war_name}":
       ensure => absent,
       force  => false,


### PR DESCRIPTION
Most ensurable resources use a `Enum['present','absent']` type, yet some of these values are checked against `false`.  In a few rare places, Boolean where accepted by a `Variant[Enum['present', 'absent'], Boolean]`(but this was not checked in the regression test suite).

Improve consistency by using a single `Enum['present','absent']` type for all ensurable parameters and only checking acceptable values in the code logic.