### PR TITLE
Add Resources support

### DIFF
--- a/manifests/config/server/resources.pp
+++ b/manifests/config/server/resources.pp
@@ -1,0 +1,112 @@
+# @summary Configure Resources elements in $CATALINA_BASE/conf/server.xml
+#
+# @param catalina_base
+#   Specifies the base directory of the Tomcat installation to manage. Valid options: a string containing an absolute path.
+# @param resources_ensure
+#   Specifies whether the resources ([The Resources Component](https://tomcat.apache.org/tomcat-8.0-doc/config/resources.html#Introduction)) should exist in the configuration file.
+# @param parent_service
+#   Specifies which Service element the Host should nest under. Valid options: a string containing the name attribute of the Service.
+# @param parent_engine
+#   Specifies which Engine element the Context should nest under. Only valid if `parent_host` is specified. Valid options: a string containing the name attribute of the Engine.
+# @param parent_host
+#   Specifies which Host element the Context should nest under. Valid options: a string containing the name attribute of the Host.
+# @param parent_context
+#   Specifies which Context element the Context should nest under. Valid options: a string containing the name attribute of the Context.
+# @param additional_attributes
+#   Specifies any further attributes to add to the Host. Valid options: a hash of '< attribute >' => '< value >' pairs.
+# @param attributes_to_remove
+#   Specifies an array of attributes to remove from the element. Valid options: an array of strings.
+# @param server_config
+#   Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
+#
+define tomcat::config::server::resources (
+  Optional[String]         $catalina_base         = undef,
+  Enum['present','absent'] $resources_ensure      = 'present',
+  Optional[String]         $parent_service        = undef,
+  Optional[String]         $parent_engine         = undef,
+  Optional[String]         $parent_host           = undef,
+  Optional[String]         $parent_context        = undef,
+  Hash                     $additional_attributes = {},
+  Array[String]            $attributes_to_remove  = [],
+  Optional[String]         $server_config         = undef,
+  Boolean                  $show_diff             = true,
+) {
+  include ::tomcat
+  $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
+  tag(sha1($_catalina_base))
+
+  if versioncmp($::augeasversion, '1.0.0') < 0 {
+    fail('Server configurations require Augeas >= 1.0.0')
+  }
+
+  if $parent_service {
+    $_parent_service = $parent_service
+  } else {
+    $_parent_service = 'Catalina'
+  }
+
+  if $parent_engine and ! $parent_host {
+    warning('context elements cannot be nested directly under engine elements, ignoring $parent_engine')
+  }
+
+  if $parent_engine and $parent_host {
+    $_parent_engine = $parent_engine
+  } else {
+    $_parent_engine = undef
+  }
+
+  if $parent_context {
+    $_parent_context = $parent_context
+  } else {
+    $_parent_context = $name
+  }
+
+  if $server_config {
+    $_server_config = $server_config
+  } else {
+    $_server_config = "${_catalina_base}/conf/server.xml"
+  }
+
+  # lint:ignore:140chars
+  if $parent_host and ! $_parent_engine {
+    $parent = "Server/Service[#attribute/name='${_parent_service}']/Engine/Host[#attribute/name='${parent_host}']/Context[#attribute/docBase='${_parent_context}']"
+  } elsif $parent_host and $_parent_engine {
+    $parent = "Server/Service[#attribute/name='${_parent_service}']/Engine[#attribute/name='${_parent_engine}']/Host[#attribute/name='${parent_host}']/Context[#attribute/docBase='${_parent_context}']"
+  } else {
+    $parent = "Server/Service[#attribute/name='${_parent_service}']/Engine/Host/Context[#attribute/docBase='${_parent_context}']"
+  }
+  $path = "${parent}/Resources"
+  # lint:endignore
+
+  if $resources_ensure == 'absent' {
+    $augeaschanges = "rm ${path}"
+  } else {
+    $_container = [
+      "set ${parent} ''",
+      "set ${path} #empty"
+    ]
+
+    if ! empty($additional_attributes) {
+      $_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${path}/#attribute/"), "'")
+    } else {
+      $_additional_attributes = undef
+    }
+
+    if ! empty(any2array($attributes_to_remove)) {
+      $_attributes_to_remove = prefix(any2array($attributes_to_remove), "rm ${path}/#attribute/")
+    } else {
+      $_attributes_to_remove = undef
+    }
+
+    $augeaschanges = delete_undef_values(flatten([$_container, $_additional_attributes, $_attributes_to_remove]))
+  }
+
+  augeas { "${_catalina_base}-${_parent_service}-${_parent_engine}-${parent_host}-context-${_parent_context}-resources":
+    lens      => 'Xml.lns',
+    incl      => $_server_config,
+    changes   => $augeaschanges,
+    show_diff => $show_diff,
+  }
+}

--- a/spec/defines/config/server/resources_spec.rb
+++ b/spec/defines/config/server/resources_spec.rb
@@ -1,0 +1,217 @@
+require 'spec_helper'
+
+describe 'tomcat::config::server::resources', type: :define do
+  let :pre_condition do
+    'class { "tomcat": }'
+  end
+  let :facts do
+    {
+      osfamily: 'Debian',
+      augeasversion: '1.0.0',
+    }
+  end
+  let :title do
+    'exampleapp.war'
+  end
+
+  context 'Add Resources' do
+    let :params do
+      {
+        catalina_base: '/opt/apache-tomcat/exampleapp',
+        resources_ensure: 'present',
+        parent_service: 'Catalina',
+        parent_engine: 'Catalina',
+        parent_host: 'localhost',
+        parent_context: 'parent',
+        server_config: '/opt/apache-tomcat/server.xml',
+        additional_attributes: {
+          'allowLinking' => 'true',
+        },
+        attributes_to_remove: [
+          'foobar',
+        ],
+      }
+    end
+
+    changes = [
+      'set Server/Service[#attribute/name=\'Catalina\']/Engine[#attribute/name=\'Catalina\']/Host[#attribute/name=\'localhost\']/Context[#attribute/docBase=\'parent\'] \'\'',
+      'set Server/Service[#attribute/name=\'Catalina\']/Engine[#attribute/name=\'Catalina\']/Host[#attribute/name=\'localhost\']/Context[#attribute/docBase=\'parent\']/Resources #empty',
+      'set Server/Service[#attribute/name=\'Catalina\']/Engine[#attribute/name=\'Catalina\']/Host[#attribute/name=\'localhost\']/Context[#attribute/docBase=\'parent\']/Resources/#attribute/allowLinking \'true\'', # rubocop:disable Metrics/LineLength
+      'rm Server/Service[#attribute/name=\'Catalina\']/Engine[#attribute/name=\'Catalina\']/Host[#attribute/name=\'localhost\']/Context[#attribute/docBase=\'parent\']/Resources/#attribute/foobar',
+    ]
+    it {
+      is_expected.to contain_augeas('/opt/apache-tomcat/exampleapp-Catalina-Catalina-localhost-context-parent-resources').with(
+        'lens'    => 'Xml.lns',
+        'incl'    => '/opt/apache-tomcat/server.xml',
+        'changes' => changes,
+      )
+    }
+  end
+  context 'No parent_context' do
+    let :params do
+      {
+        catalina_base: '/opt/apache-tomcat/exampleapp',
+        resources_ensure: 'present',
+        parent_service: 'Catalina',
+        parent_engine: 'Catalina',
+        parent_host: 'localhost',
+        additional_attributes: {
+          'foo' => 'bar',
+        },
+        attributes_to_remove: [
+          'foobar',
+        ],
+      }
+    end
+
+    changes = [
+      'set Server/Service[#attribute/name=\'Catalina\']/Engine[#attribute/name=\'Catalina\']/Host[#attribute/name=\'localhost\']/Context[#attribute/docBase=\'exampleapp.war\'] \'\'', # rubocop:disable Metrics/LineLength
+      'set Server/Service[#attribute/name=\'Catalina\']/Engine[#attribute/name=\'Catalina\']/Host[#attribute/name=\'localhost\']/Context[#attribute/docBase=\'exampleapp.war\']/Resources #empty', # rubocop:disable Metrics/LineLength
+      'set Server/Service[#attribute/name=\'Catalina\']/Engine[#attribute/name=\'Catalina\']/Host[#attribute/name=\'localhost\']/Context[#attribute/docBase=\'exampleapp.war\']/Resources/#attribute/foo \'bar\'', # rubocop:disable Metrics/LineLength
+      'rm Server/Service[#attribute/name=\'Catalina\']/Engine[#attribute/name=\'Catalina\']/Host[#attribute/name=\'localhost\']/Context[#attribute/docBase=\'exampleapp.war\']/Resources/#attribute/foobar', # rubocop:disable Metrics/LineLength
+    ]
+    it {
+      is_expected.to contain_augeas('/opt/apache-tomcat/exampleapp-Catalina-Catalina-localhost-context-exampleapp.war-resources').with(
+        'lens'    => 'Xml.lns',
+        'incl'    => '/opt/apache-tomcat/exampleapp/conf/server.xml',
+        'changes' => changes,
+      )
+    }
+  end
+  context 'context with $parent_service' do
+    let :params do
+      {
+        catalina_base: '/opt/apache-tomcat/exampleapp',
+        resources_ensure: 'present',
+        parent_service: 'test',
+      }
+    end
+
+    it {
+      is_expected.to contain_augeas('/opt/apache-tomcat/exampleapp-test---context-exampleapp.war-resources').with(
+        'lens'    => 'Xml.lns',
+        'incl'    => '/opt/apache-tomcat/exampleapp/conf/server.xml',
+        'changes' => [
+          'set Server/Service[#attribute/name=\'test\']/Engine/Host/Context[#attribute/docBase=\'exampleapp.war\'] \'\'',
+          'set Server/Service[#attribute/name=\'test\']/Engine/Host/Context[#attribute/docBase=\'exampleapp.war\']/Resources #empty',
+        ],
+      )
+    }
+  end
+  context 'context with $parent_host' do
+    let :params do
+      {
+        catalina_base: '/opt/apache-tomcat/exampleapp',
+        resources_ensure: 'present',
+        parent_host: 'localhost',
+      }
+    end
+
+    it {
+      is_expected.to contain_augeas('/opt/apache-tomcat/exampleapp-Catalina--localhost-context-exampleapp.war-resources').with(
+        'lens'    => 'Xml.lns',
+        'incl'    => '/opt/apache-tomcat/exampleapp/conf/server.xml',
+        'changes' => [
+          'set Server/Service[#attribute/name=\'Catalina\']/Engine/Host[#attribute/name=\'localhost\']/Context[#attribute/docBase=\'exampleapp.war\'] \'\'',
+          'set Server/Service[#attribute/name=\'Catalina\']/Engine/Host[#attribute/name=\'localhost\']/Context[#attribute/docBase=\'exampleapp.war\']/Resources #empty',
+        ],
+      )
+    }
+  end
+  context '$parent_engine, no $parent_host' do
+    let :params do
+      {
+        catalina_base: '/opt/apache-tomcat/exampleapp',
+        resources_ensure: 'present',
+        parent_engine: 'Catalina',
+      }
+    end
+
+    it {
+      is_expected.to contain_augeas('/opt/apache-tomcat/exampleapp-Catalina---context-exampleapp.war-resources').with(
+        'lens'    => 'Xml.lns',
+        'incl'    => '/opt/apache-tomcat/exampleapp/conf/server.xml',
+        'changes' => [
+          'set Server/Service[#attribute/name=\'Catalina\']/Engine/Host/Context[#attribute/docBase=\'exampleapp.war\'] \'\'',
+          'set Server/Service[#attribute/name=\'Catalina\']/Engine/Host/Context[#attribute/docBase=\'exampleapp.war\']/Resources #empty',
+        ],
+      )
+    }
+  end
+  context 'Remove Resources' do
+    let :params do
+      {
+        catalina_base: '/opt/apache-tomcat/exampleapp',
+        resources_ensure: 'absent',
+        parent_service: 'Catalina',
+        parent_engine: 'Catalina',
+        parent_host: 'localhost',
+      }
+    end
+
+    it {
+      is_expected.to contain_augeas('/opt/apache-tomcat/exampleapp-Catalina-Catalina-localhost-context-exampleapp.war-resources').with(
+        'lens'    => 'Xml.lns',
+        'incl'    => '/opt/apache-tomcat/exampleapp/conf/server.xml',
+        'changes' => [
+          'rm Server/Service[#attribute/name=\'Catalina\']/Engine[#attribute/name=\'Catalina\']/Host[#attribute/name=\'localhost\']/Context[#attribute/docBase=\'exampleapp.war\']/Resources',
+        ],
+      )
+    }
+  end
+  describe 'Failing Tests' do
+    context 'bad resources_ensure' do
+      let :params do
+        {
+          resources_ensure: 'foo',
+        }
+      end
+
+      it do
+        expect {
+          catalogue
+        }.to raise_error(Puppet::Error, %r{(String|foo)})
+      end
+    end
+    context 'Bad additional_attributes' do
+      let :params do
+        {
+          additional_attributes: 'foo',
+        }
+      end
+
+      it do
+        expect {
+          catalogue
+        }. to raise_error(Puppet::Error, %r{Hash})
+      end
+    end
+    context 'Bad attributes_to_remove' do
+      let :params do
+        {
+          attributes_to_remove: 'foo',
+        }
+      end
+
+      it do
+        expect {
+          catalogue
+        }. to raise_error(Puppet::Error, %r{Array})
+      end
+    end
+    context 'old augeas' do
+      let :facts do
+        {
+          osfamily: 'Debian',
+          augeasversion: '0.10.0',
+        }
+      end
+
+      it do
+        expect {
+          catalogue
+        }.to raise_error(Puppet::Error, %r{configurations require Augeas})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Tomcat 8 introduced [Resources] and some settings where moved arround:

```
<!-- Tomcat 7: -->
<Context allowLinking="true" />

<!-- Tomcat 8: -->
<Context>
  <Resources allowLinking="true" />
</Context>
```

This commit introduce a new `tomcat::config::server::resources` defined type which allows to configure such settings:

```
tomcat::config::server::resources { 'app resources':
  parent_host           => 'localhost',
  parent_context        => '/opt/app',
  additional_attributes => {
    allowLinking => true,
  },
}
```

[Resources]: https://tomcat.apache.org/tomcat-8.0-doc/config/resources.html