### PR TITLE
Allow override status_command in case of use_init

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -141,7 +141,7 @@ define tomcat::service (
     $_hasrestart   = true
     $_start        = $start_command
     $_stop         = $stop_command
-    $_status       = undef
+    $_status       = $status_command
     $_provider     = undef
   } else {
     $_service_name = "tomcat-${name}"


### PR DESCRIPTION
In the service, if `use_init` is set to `true`, it's impossible to override `status_command`. 

It can be usefull to allow override it by example when the JVM option `-XX:+ExitOnOutOfMemoryError` : the systemctl status becomes `active (exited)` and the module does not restart the service. A solution is to override `status_command` by `/bin/systemctl show -p SubState --value <instance name> | grep running`.