### PR TITLE
Increase puppetlabs/concat lower bound

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.1.0 < 7.0.0"
+      "version_requirement": ">= 4.0.0 < 7.0.0"
     },
     {
       "name": "puppet/archive",


### PR DESCRIPTION
Bumping up puppetlabs/concat lower bound dependency.

In concat 4.0+, ensure was removed from concat::fragment. The code with puppetlabs/tomcat was already fixed with the PR below:

https://github.com/puppetlabs/puppetlabs-tomcat/pull/206

puppetlabs/tomcat <= 1.6, tomcat::setenv::entry will not work with puppetlabs/concat >= 4.0  
