### PR TITLE
Added multi parent realms. Added context resources and transaction.

### DIFF
--- a/manifests/config/context/resource.pp
+++ b/manifests/config/context/resource.pp
@@ -2,12 +2,15 @@
 #
 # @param ensure
 #   Specifies whether you are trying to add or remove the Resource element.
+# @param type
+#   The type of resource element. EX: Resource, PreResource, PostResource, etc
 # @param resource_name
 #   The name of the Resource to be created, relative to the `java:comp/env` context. `$name`.
 # @param name
 #   `$resource_name`
 # @param resource_type
-#   The fully qualified Java class name expected by the web application when it performs a lookup for this resource. Required to create the resource.
+#   The fully qualified Java class name expected by the web application when it performs a lookup for this resource.
+#   Required to create the resource.
 # @param catalina_base
 #   Specifies the root of the Tomcat installation. 
 # @param additional_attributes
@@ -19,8 +22,10 @@
 #
 define tomcat::config::context::resource (
   Enum['present','absent'] $ensure = 'present',
+  String $type                     = 'Resource',
   $resource_name                   = $name,
   $resource_type                   = undef,
+  $parent_resources_name           = undef,
   $catalina_base                   = $::tomcat::catalina_home,
   Hash $additional_attributes      = {},
   Array $attributes_to_remove      = [],
@@ -36,7 +41,12 @@ define tomcat::config::context::resource (
     $_resource_name = $name
   }
 
-  $base_path = "Context/Resource[#attribute/name='${_resource_name}']"
+  $_resource_path = "${type}[#attribute/name='${_resource_name}']"
+  if $parent_resources_name {
+    $base_path = "Context/Resources[#attribute/puppetName='${parent_resources_name}']/${_resource_path}"
+  } else {
+    $base_path = "Context/${_resource_path}"
+  }
 
   if $ensure == 'absent' {
     $changes = "rm ${base_path}"

--- a/manifests/config/context/resources.pp
+++ b/manifests/config/context/resources.pp
@@ -1,0 +1,68 @@
+# @summary Configure Resources elements in $CATALINA_BASE/conf/context.xml
+#
+# @param catalina_base
+#   Specifies the base directory of the Tomcat installation to manage. Valid options: a string containing an absolute path.
+# @param ensure
+#   Specifies whether the resources ([The Resources Component](https://tomcat.apache.org/tomcat-8.0-doc/config/resources.html#Introduction)) should exist in the configuration file.
+# @param additional_attributes
+#   Specifies any further attributes to add to the Host. Valid options: a hash of '< attribute >' => '< value >' pairs.
+# @param attributes_to_remove
+#   Specifies an array of attributes to remove from the element. Valid options: an array of strings.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
+#
+define tomcat::config::context::resources(
+  Optional[String] $catalina_base     = undef,
+  Optional[String] $resources_name    = undef,
+  Enum['present','absent'] $ensure    = 'present',
+  Hash $additional_attributes         = {},
+  Array[String] $attributes_to_remove = [],
+  Boolean $show_diff                  = true,
+) {
+  include ::tomcat
+  $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
+  tag(sha1($_catalina_base))
+
+  if versioncmp($::augeasversion, '1.0.0') < 0 {
+    fail('Server configurations require Augeas >= 1.0.0')
+  }
+
+  if $resources_name {
+    $_resources_name = $resources_name
+  } else {
+    $_resources_name = $name
+  }
+
+  $path = "Context/Resources[#attribute/puppetName='${_resources_name}']"
+
+  if $ensure == 'absent' {
+    $augeaschanges = "rm ${path}"
+  } else {
+    $set_name = "set ${path}/#attribute/puppetName ${_resources_name}"
+
+    if ! empty($additional_attributes) {
+      $_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${path}/#attribute/"), "'")
+    } else {
+      $_additional_attributes = undef
+    }
+
+    if ! empty(any2array($attributes_to_remove)) {
+      $_attributes_to_remove = prefix(any2array($attributes_to_remove), "rm ${path}/#attribute/")
+    } else {
+      $_attributes_to_remove = undef
+    }
+
+    $augeaschanges = delete_undef_values(flatten([
+      $set_name,
+      $_additional_attributes,
+      $_attributes_to_remove,
+    ]))
+  }
+
+  augeas { "context-${catalina_base}-resources-${name}":
+    lens      => 'Xml.lns',
+    incl      => "${catalina_base}/conf/context.xml",
+    changes   => $augeaschanges,
+    show_diff => $show_diff,
+  }
+}

--- a/manifests/config/context/transaction.pp
+++ b/manifests/config/context/transaction.pp
@@ -1,0 +1,75 @@
+# @summary Configure Transaction elements in $CATALINA_BASE/conf/context.xml
+#
+# @param catalina_base
+#   Specifies the base directory of the Tomcat installation to manage. Valid options: a string containing an absolute path.
+# @param transaction_name
+#   The name of the transaciton.
+# @param factory
+#   The class name for the JNDI object factory.
+# @param ensure
+#   Specifies whether the transaction element should exist in the configuration file.
+# @param additional_attributes
+#   Specifies any further attributes to add to the Host. Valid options: a hash of '< attribute >' => '< value >' pairs.
+# @param attributes_to_remove
+#   Specifies an array of attributes to remove from the element. Valid options: an array of strings.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
+#
+define tomcat::config::context::transaction(
+  Optional[String] $catalina_base     = undef,
+  Optional[String] $transaction_name  = undef,
+  String $factory                     = undef,
+  Enum['present','absent'] $ensure    = 'present',
+  Hash $additional_attributes         = {},
+  Array[String] $attributes_to_remove = [],
+  Boolean $show_diff                  = true,
+) {
+  include ::tomcat
+  $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
+  tag(sha1($_catalina_base))
+
+  if versioncmp($::augeasversion, '1.0.0') < 0 {
+    fail('Server configurations require Augeas >= 1.0.0')
+  }
+
+  if $transaction_name {
+    $_transaction_name = $transaction_name
+  } else {
+    $_transaction_name = $name
+  }
+
+  $path = "Context/Transaction[#attribute/puppetName='${_transaction_name}']"
+
+  if $ensure == 'absent' {
+    $augeaschanges = "rm ${path}"
+  } else {
+    $set_name = "set ${path}/#attribute/puppetName ${_transaction_name}"
+    $set_factory = "set ${path}/#attribute/factory ${factory}"
+
+    if ! empty($additional_attributes) {
+      $_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${path}/#attribute/"), "'")
+    } else {
+      $_additional_attributes = undef
+    }
+
+    if ! empty(any2array($attributes_to_remove)) {
+      $_attributes_to_remove = prefix(any2array($attributes_to_remove), "rm ${path}/#attribute/")
+    } else {
+      $_attributes_to_remove = undef
+    }
+
+    $augeaschanges = delete_undef_values(flatten([
+      $set_name,
+      $set_factory,
+      $_additional_attributes,
+      $_attributes_to_remove,
+    ]))
+  }
+
+  augeas { "context-${catalina_base}-transaction-${name}":
+    lens      => 'Xml.lns',
+    incl      => "${catalina_base}/conf/context.xml",
+    changes   => $augeaschanges,
+    show_diff => $show_diff,
+  }
+}

--- a/manifests/config/server/executor.pp
+++ b/manifests/config/server/executor.pp
@@ -1,0 +1,73 @@
+# @summary Configure Executor elements in $CATALINA_BASE/conf/server.xml
+#
+# @param catalina_base
+#   Specifies the base directory of the Tomcat installation to manage. Valid options: a string containing an absolute path.
+# @param executor_name
+#   The name of the executor element.
+# @param ensure
+#   Specifies whether the executor ([The Executor Component](https://tomcat.apache.org/tomcat-8.0-doc/config/executor.html)) should exist in the configuration file.
+# @param parent_service
+#   Specifies which Service element the Listener should nest under. Only valid if `parent_engine` or `parent_host` is specified. Valid options: a string containing the name attribute of the Service.
+# @param additional_attributes
+#   Specifies any further attributes to add to the Host. Valid options: a hash of '< attribute >' => '< value >' pairs.
+# @param attributes_to_remove
+#   Specifies an array of attributes to remove from the element. Valid options: an array of strings.
+# @param show_diff
+#   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
+#
+define tomcat::config::server::executor(
+  Optional[String] $catalina_base     = undef,
+  Optional[String] $executor_name     = undef,
+  Optional[String] $parent_service    = 'Catalina',
+  Enum['present','absent'] $ensure    = 'present',
+  Hash $additional_attributes         = {},
+  Array[String] $attributes_to_remove = [],
+  Boolean $show_diff                  = true,
+) {
+  include ::tomcat
+  $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
+  tag(sha1($_catalina_base))
+
+  if versioncmp($::augeasversion, '1.0.0') < 0 {
+    fail('Server configurations require Augeas >= 1.0.0')
+  }
+
+  if $executor_name {
+    $_executor_name = $executor_name
+  } else {
+    $_executor_name = $name
+  }
+
+  $path = "Server/Service[#attribute/name='${parent_service}']/Executor[#attribute/name='${_executor_name}']"
+
+  if $ensure == 'absent' {
+    $augeaschanges = "rm ${path}"
+  } else {
+    $set_name = "set ${path}/#attribute/name ${_executor_name}"
+
+    if ! empty($additional_attributes) {
+      $_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${path}/#attribute/"), "'")
+    } else {
+      $_additional_attributes = undef
+    }
+
+    if ! empty(any2array($attributes_to_remove)) {
+      $_attributes_to_remove = prefix(any2array($attributes_to_remove), "rm ${path}/#attribute/")
+    } else {
+      $_attributes_to_remove = undef
+    }
+
+    $augeaschanges = delete_undef_values(flatten([
+      $set_name,
+      $_additional_attributes,
+      $_attributes_to_remove,
+    ]))
+  }
+
+  augeas { "server-${catalina_base}-executor-${name}":
+    lens      => 'Xml.lns',
+    incl      => "${catalina_base}/conf/server.xml",
+    changes   => $augeaschanges,
+    show_diff => $show_diff,
+  }
+}

--- a/spec/defines/config/context/resource_spec.rb
+++ b/spec/defines/config/context/resource_spec.rb
@@ -68,4 +68,83 @@ describe 'tomcat::config::context::resource', type: :define do
       )
     }
   end
+  context 'Add PostResource' do
+    let :params do
+      {
+        catalina_base: '/opt/apache-tomcat/test',
+        resource_type: 'net.sourceforge.jtds.jdbcx.JtdsDataSource',
+        type: 'PostResource',
+        additional_attributes: {
+          'auth'            => 'Container',
+          'closeMethod'     => 'closeMethod',
+          'validationQuery' => 'getdate()',
+          'description'     => 'description',
+          'scope'           => 'Shareable',
+          'singleton'       => 'true',
+        },
+        attributes_to_remove: [
+          'foobar',
+        ],
+      }
+    end
+
+    changes = [
+      'set Context/PostResource[#attribute/name=\'jdbc\']/#attribute/name jdbc',
+      'set Context/PostResource[#attribute/name=\'jdbc\']/#attribute/type net.sourceforge.jtds.jdbcx.JtdsDataSource',
+      'set Context/PostResource[#attribute/name=\'jdbc\']/#attribute/auth \'Container\'',
+      'set Context/PostResource[#attribute/name=\'jdbc\']/#attribute/closeMethod \'closeMethod\'',
+      'set Context/PostResource[#attribute/name=\'jdbc\']/#attribute/validationQuery \'getdate()\'',
+      'set Context/PostResource[#attribute/name=\'jdbc\']/#attribute/description \'description\'',
+      'set Context/PostResource[#attribute/name=\'jdbc\']/#attribute/scope \'Shareable\'',
+      'set Context/PostResource[#attribute/name=\'jdbc\']/#attribute/singleton \'true\'',
+      'rm Context/PostResource[#attribute/name=\'jdbc\']/#attribute/foobar',
+    ]
+    it {
+      is_expected.to contain_augeas('context-/opt/apache-tomcat/test-resource-jdbc').with(
+        'lens' => 'Xml.lns',
+        'incl' => '/opt/apache-tomcat/test/conf/context.xml',
+        'changes' => changes,
+      )
+    }
+  end
+  context 'Add PreResource with parent' do
+    let :params do
+      {
+        catalina_base: '/opt/apache-tomcat/test',
+        resource_type: 'net.sourceforge.jtds.jdbcx.JtdsDataSource',
+        type: 'PreResource',
+        parent_resources_name: 'Resources',
+        additional_attributes: {
+          'auth'            => 'Container',
+          'closeMethod'     => 'closeMethod',
+          'validationQuery' => 'getdate()',
+          'description'     => 'description',
+          'scope'           => 'Shareable',
+          'singleton'       => 'true',
+        },
+        attributes_to_remove: [
+          'foobar',
+        ],
+      }
+    end
+
+    changes = [
+      'set Context/Resources[#attribute/puppetName=\'Resources\']/PreResource[#attribute/name=\'jdbc\']/#attribute/name jdbc',
+      'set Context/Resources[#attribute/puppetName=\'Resources\']/PreResource[#attribute/name=\'jdbc\']/#attribute/type net.sourceforge.jtds.jdbcx.JtdsDataSource',
+      'set Context/Resources[#attribute/puppetName=\'Resources\']/PreResource[#attribute/name=\'jdbc\']/#attribute/auth \'Container\'',
+      'set Context/Resources[#attribute/puppetName=\'Resources\']/PreResource[#attribute/name=\'jdbc\']/#attribute/closeMethod \'closeMethod\'',
+      'set Context/Resources[#attribute/puppetName=\'Resources\']/PreResource[#attribute/name=\'jdbc\']/#attribute/validationQuery \'getdate()\'',
+      'set Context/Resources[#attribute/puppetName=\'Resources\']/PreResource[#attribute/name=\'jdbc\']/#attribute/description \'description\'',
+      'set Context/Resources[#attribute/puppetName=\'Resources\']/PreResource[#attribute/name=\'jdbc\']/#attribute/scope \'Shareable\'',
+      'set Context/Resources[#attribute/puppetName=\'Resources\']/PreResource[#attribute/name=\'jdbc\']/#attribute/singleton \'true\'',
+      'rm Context/Resources[#attribute/puppetName=\'Resources\']/PreResource[#attribute/name=\'jdbc\']/#attribute/foobar',
+    ]
+    it {
+      is_expected.to contain_augeas('context-/opt/apache-tomcat/test-resource-jdbc').with(
+        'lens' => 'Xml.lns',
+        'incl' => '/opt/apache-tomcat/test/conf/context.xml',
+        'changes' => changes,
+      )
+    }
+  end
 end

--- a/spec/defines/config/context/resources_spec.rb
+++ b/spec/defines/config/context/resources_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'tomcat::config::context::resources' do
+  let :pre_condition do
+    'class { "tomcat": }'
+  end
+  let :title do
+    'Resources'
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      merged_facts = if os =~ %r{debian}
+                       os_facts.merge(
+                         'augeasversion' => '1.0.0',
+                       )
+                     else
+                       os_facts
+                     end
+      let(:facts) { merged_facts }
+
+      context 'Add Resources' do
+        let :params do
+          {
+            catalina_base: '/opt/apache-tomcat/test',
+            ensure: 'present',
+            additional_attributes: {
+              'allowLinking' => 'true',
+            },
+            attributes_to_remove: [
+              'foobar',
+            ],
+          }
+        end
+
+        changes = [
+          'set Context/Resources[#attribute/puppetName=\'Resources\']/#attribute/puppetName Resources',
+          'set Context/Resources[#attribute/puppetName=\'Resources\']/#attribute/allowLinking \'true\'',
+          'rm Context/Resources[#attribute/puppetName=\'Resources\']/#attribute/foobar',
+        ]
+        it {
+          is_expected.to contain_augeas('context-/opt/apache-tomcat/test-resources-Resources').with(
+            'lens' => 'Xml.lns',
+            'incl' => '/opt/apache-tomcat/test/conf/context.xml',
+            'changes' => changes,
+          )
+        }
+
+        it { is_expected.to compile }
+      end
+    end
+  end
+end

--- a/spec/defines/config/context/transition_spec.rb
+++ b/spec/defines/config/context/transition_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'tomcat::config::context::transaction' do
+  let :pre_condition do
+    'class { "tomcat": }'
+  end
+  let :title do
+    'UserTransaction'
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      merged_facts = if os =~ %r{debian}
+                       os_facts.merge(
+                         'augeasversion' => '1.0.0',
+                       )
+                     else
+                       os_facts
+                     end
+      let(:facts) { merged_facts }
+
+      context 'Add Transaction' do
+        let :params do
+          {
+            catalina_base: '/opt/apache-tomcat/test',
+            ensure: 'present',
+            factory: 'org.objectweb.jotm.UserTransactionFactory',
+            additional_attributes: {
+              'jotm.timeout' => '60',
+            },
+            attributes_to_remove: [
+              'foobar',
+            ],
+          }
+        end
+
+        changes = [
+          'set Context/Transaction[#attribute/puppetName=\'UserTransaction\']/#attribute/puppetName UserTransaction',
+          'set Context/Transaction[#attribute/puppetName=\'UserTransaction\']/#attribute/factory org.objectweb.jotm.UserTransactionFactory',
+          'set Context/Transaction[#attribute/puppetName=\'UserTransaction\']/#attribute/jotm.timeout \'60\'',
+          'rm Context/Transaction[#attribute/puppetName=\'UserTransaction\']/#attribute/foobar',
+        ]
+        it {
+          is_expected.to contain_augeas('context-/opt/apache-tomcat/test-transaction-UserTransaction').with(
+            'lens' => 'Xml.lns',
+            'incl' => '/opt/apache-tomcat/test/conf/context.xml',
+            'changes' => changes,
+          )
+        }
+
+        it { is_expected.to compile }
+      end
+    end
+  end
+end

--- a/spec/defines/config/server/executor_spec.rb
+++ b/spec/defines/config/server/executor_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'tomcat::config::server::executor' do
+  let :pre_condition do
+    'class { "tomcat": }'
+  end
+  let :title do
+    'tomcatThreadPool'
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      merged_facts = if os =~ %r{debian}
+                       os_facts.merge(
+                         'augeasversion' => '1.0.0',
+                       )
+                     else
+                       os_facts
+                     end
+      let(:facts) { merged_facts }
+
+      context 'Add Executor' do
+        let :params do
+          {
+            catalina_base: '/opt/apache-tomcat/test',
+            ensure: 'present',
+            additional_attributes: {
+              'namePrefix'      => 'catalina-exec-',
+              'maxThreads'      => '100',
+              'minSpareThreads' => '4',
+            },
+            attributes_to_remove: [
+              'foobar',
+            ],
+          }
+        end
+
+        changes = [
+          'set Server/Service[#attribute/name=\'Catalina\']/Executor[#attribute/name=\'tomcatThreadPool\']/#attribute/name tomcatThreadPool',
+          'set Server/Service[#attribute/name=\'Catalina\']/Executor[#attribute/name=\'tomcatThreadPool\']/#attribute/namePrefix \'catalina-exec-\'',
+          'set Server/Service[#attribute/name=\'Catalina\']/Executor[#attribute/name=\'tomcatThreadPool\']/#attribute/maxThreads \'100\'',
+          'set Server/Service[#attribute/name=\'Catalina\']/Executor[#attribute/name=\'tomcatThreadPool\']/#attribute/minSpareThreads \'4\'',
+          'rm Server/Service[#attribute/name=\'Catalina\']/Executor[#attribute/name=\'tomcatThreadPool\']/#attribute/foobar',
+        ]
+        it {
+          is_expected.to contain_augeas('server-/opt/apache-tomcat/test-executor-tomcatThreadPool').with(
+            'lens' => 'Xml.lns',
+            'incl' => '/opt/apache-tomcat/test/conf/server.xml',
+            'changes' => changes,
+          )
+        }
+
+        it { is_expected.to compile }
+      end
+    end
+  end
+end

--- a/spec/defines/config/server/realm_spec.rb
+++ b/spec/defines/config/server/realm_spec.rb
@@ -93,6 +93,7 @@ describe 'tomcat::config::server::realm', type: :define do
 
     # rubocop:disable Metrics/LineLength
     changes = [
+      'rm //Realm//Realm//Realm',
       'rm //Realm//Realm',
       'rm //Context//Realm',
       'rm //Host//Realm',
@@ -350,6 +351,42 @@ describe 'tomcat::config::server::realm', type: :define do
         'changes' => changes,
       )
     }
+  end
+  context 'Add Realm with $parent_realm only - multiple parents' do
+    let :title do
+      'org.apache.catalina.realm.JNDIRealm'
+    end
+    let :params do
+      {
+        catalina_base: '/opt/apache-tomcat/test',
+        parent_realm: 'org.apache.catalina.realm.LockOutRealm,org.apache.catalina.realm.CombinedRealm',
+        realm_ensure: 'present',
+        additional_attributes: {
+          'connectionURL' => 'ldap://localhost',
+          'roleName'      => 'cn',
+          'roleSearch'    => 'member={0}',
+          'spaces'        => 'foo bar',
+        },
+      }
+    end
+
+    # rubocop:disable Metrics/LineLength
+    changes = [
+      "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.CombinedRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/puppetName 'org.apache.catalina.realm.JNDIRealm'",
+      "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.CombinedRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/className 'org.apache.catalina.realm.JNDIRealm'",
+      "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.CombinedRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/connectionURL 'ldap://localhost'",
+      "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.CombinedRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/roleName 'cn'",
+      "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.CombinedRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/roleSearch 'member={0}'",
+      "set Server/Service[#attribute/name='Catalina']/Engine[#attribute/name='Catalina']/Realm[#attribute/className='org.apache.catalina.realm.LockOutRealm']/Realm[#attribute/className='org.apache.catalina.realm.CombinedRealm']/Realm[#attribute/puppetName='org.apache.catalina.realm.JNDIRealm' or (count(#attribute/puppetName)=0 and #attribute/className='org.apache.catalina.realm.JNDIRealm')]/#attribute/spaces 'foo bar'",
+    ]
+    it {
+      is_expected.to contain_augeas('/opt/apache-tomcat/test-Catalina-Catalina--org.apache.catalina.realm.LockOutRealm,org.apache.catalina.realm.CombinedRealm-realm-org.apache.catalina.realm.JNDIRealm').with(
+        'lens' => 'Xml.lns',
+        'incl' => '/opt/apache-tomcat/test/conf/server.xml',
+        'changes' => changes,
+      )
+    }
+    # rubocop:enable Metrics/LineLength
   end
   context 'Failing Tests' do
     context 'Bad realm_ensure' do


### PR DESCRIPTION
Adds the ability to create a realm that is nested within multiple realms.

Example of realm hierarchy:

- LockOutRealm
  - CombinedRealm
    - JNDIRealm1
    - JNDIRealm2
    - JNDIRealm3

To specify multiple parents, use the parent realm parameter and specify them in order separated by comma. I did this to ensure I wouldn't break any existing implementation of this module.
```
 parent_realm => 'org.apache.catalina.realm.LockOutRealm,org.apache.catalina.realm.CombinedRealm'
```

Adds the \<Resources\> element within context.xml

Adds different type of \<Resource\> elements within context.xml. Ex: \<PreResources\>, \<PostResources\>

Adds the \<Transaction\> element within context.xml