### PR TITLE
Removed tomcat::config::context::valve::resource_name

### DIFF
--- a/manifests/config/context/valve.pp
+++ b/manifests/config/context/valve.pp
@@ -2,12 +2,9 @@
 #
 # @param ensure
 #   Specifies whether you are trying to add or remove the Valve element.
-# @param resource_name
-#   The name of the Resource to be created, relative to the java:comp/env context. Default: `$name`
-# @param name
-#   `$resource_name`
 # @param resource_type
-#   The fully qualified Java class name expected by the web application when it performs a lookup for this resource. Required to create the resource.
+#   The fully qualified Java class name expected by the web application when it performs a lookup for this resource.
+#   Required to create the resource. Default: `$name`
 # @param catalina_base
 #   Specifies the root of the Tomcat installation. Default: `$tomcat::catalina_home`
 # @param additional_attributes
@@ -19,8 +16,7 @@
 #
 define tomcat::config::context::valve (
   Enum['present','absent'] $ensure = 'present',
-  $resource_name                   = $name,
-  $resource_type                   = undef,
+  $resource_type                   = $name,
   $catalina_base                   = $::tomcat::catalina_home,
   Hash $additional_attributes      = {},
   Array $attributes_to_remove      = [],
@@ -30,24 +26,12 @@ define tomcat::config::context::valve (
     fail('Server configurations require Augeas >= 1.0.0')
   }
 
-  if $resource_name {
-    $_resource_name = $resource_name
-  } else {
-    $_resource_name = $name
-  }
-
-  $base_path = "Context/Valve[#attribute/name='${_resource_name}']"
+  $base_path = "Context/Valve[#attribute/className='${resource_type}']"
 
   if $ensure == 'absent' {
     $changes = "rm ${base_path}"
   } else {
-    # (MODULES-3353) does this need to be quoted?
-    $set_name = "set ${base_path}/#attribute/name ${_resource_name}"
-    if $resource_type {
-      $set_type = "set ${base_path}/#attribute/className ${resource_type}"
-    } else {
-      $set_type = undef
-    }
+    $set_type = "set ${base_path}/#attribute/className ${resource_type}"
 
     if ! empty($additional_attributes) {
       $set_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${base_path}/#attribute/"), "'")
@@ -62,7 +46,6 @@ define tomcat::config::context::valve (
 
 
     $changes = delete_undef_values(flatten([
-      $set_name,
       $set_type,
       $set_additional_attributes,
       $rm_attributes_to_remove,

--- a/spec/acceptance/acceptance_1b_spec.rb
+++ b/spec/acceptance/acceptance_1b_spec.rb
@@ -120,12 +120,12 @@ describe 'Acceptance case one', unless: stop_test do
     end
     it 'is serving a page on port 80', retry: 5, retry_wait: 10 do
       run_shell('curl --retry 10 --retry-delay 15 localhost:80/war_one/hello.jsp') do |r|
-        r.stdout.should match(%r{Sample Application JSP Page})
+        expect(r.stdout).to match(%r{Sample Application JSP Page})
       end
     end
     it 'is serving a page on port 8080', retry: 5, retry_wait: 10 do
       run_shell('curl --retry 10 --retry-delay 15 localhost:8080/war_one/hello.jsp') do |r|
-        r.stdout.should match(%r{Sample Application JSP Page})
+        expect(r.stdout).to match(%r{Sample Application JSP Page})
       end
     end
   end
@@ -171,7 +171,7 @@ describe 'Acceptance case one', unless: stop_test do
     end
     it 'is serving a page on port 80', retry: 5, retry_wait: 10 do
       run_shell('curl --retry 10 --retry-delay 15 localhost:80/war_one/hello.jsp') do |r|
-        r.stdout.should match(%r{Sample Application JSP Page})
+        expect(r.stdout).to match(%r{Sample Application JSP Page})
       end
     end
   end
@@ -189,7 +189,7 @@ describe 'Acceptance case one', unless: stop_test do
     end
     it 'does not have deployed the war', retry: 5, retry_wait: 10 do
       run_shell('curl localhost:80/war_one/hello.jsp') do |r|
-        r.stdout.should match(%r{The origin server did not find a current representation for the target resource})
+        expect(r.stdout).to match(%r{The origin server did not find a current representation for the target resource})
       end
     end
   end

--- a/spec/acceptance/acceptance_3b_spec.rb
+++ b/spec/acceptance/acceptance_3b_spec.rb
@@ -306,4 +306,19 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       end
     end
   end
+  context 'add a context valve' do
+    pp = <<-MANIFEST
+      tomcat::config::context::valve { 'org.apache.catalina.valves.rewrite.RewriteValve':
+        catalina_base => '/opt/apache-tomcat8/tomcat8',
+      }
+    MANIFEST
+    it 'applies the manifest without error' do
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
+    end
+    it 'has changed the context.xml file' do
+      run_shell('cat /opt/apache-tomcat8/tomcat8/conf/context.xml') do |r|
+        r.stdout.should match(%r{<Valve className="org.apache.catalina.valves.rewrite.RewriteValve"><\/Valve>})
+      end
+    end
+  end
 end

--- a/spec/acceptance/acceptance_3b_spec.rb
+++ b/spec/acceptance/acceptance_3b_spec.rb
@@ -58,12 +58,12 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
     end
     it 'is serving a page on port 8180', retry: 5, retry_wait: 10 do
       run_shell('curl --retry 10 --retry-delay 15 localhost:8180') do |r|
-        r.stdout.should match(%r{The origin server did not find a current representation for the target resource})
+        expect(r.stdout).to match(%r{The origin server did not find a current representation for the target resource})
       end
     end
     it 'is serving a JSP page from the war', retry: 5, retry_wait: 10 do
       run_shell('curl --retry 10 --retry-delay 15 localhost:8180/tomcat8-sample/hello.jsp') do |r|
-        r.stdout.should match(%r{Sample Application JSP Page})
+        expect(r.stdout).to match(%r{Sample Application JSP Page})
       end
     end
   end
@@ -99,7 +99,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
     end
     it 'is serving a page on port 8180', retry: 5, retry_wait: 10 do
       run_shell('curl --retry 10 --retry-delay 15 localhost:8180') do |r|
-        r.stdout.should match(%r{The origin server did not find a current representation for the target resource})
+        expect(r.stdout).to match(%r{The origin server did not find a current representation for the target resource})
       end
     end
   end
@@ -117,7 +117,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
     end
     it 'does not have deployed the war', retry: 5, retry_wait: 10 do
       run_shell('curl --retry 10 --retry-delay 15 localhost:8180/tomcat8-sample/hello.jsp') do |r|
-        r.stdout.should match(%r{The origin server did not find a current representation for the target resource})
+        expect(r.stdout).to match(%r{The origin server did not find a current representation for the target resource})
       end
     end
   end
@@ -160,7 +160,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
     end
     it 'shoud have a service named FooBar and a class names FooBar' do
       run_shell('cat /opt/apache-tomcat8/tomcat8/conf/server.xml') do |r|
-        r.stdout.should match(%r{<Service name="org.apache.catalina.core.StandardService" className="org.apache.catalina.core.StandardService"><\/Service>})
+        expect(r.stdout).to match(%r{<Service name="org.apache.catalina.core.StandardService" className="org.apache.catalina.core.StandardService"><\/Service>})
       end
     end
   end
@@ -177,7 +177,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
     end
     it 'has changed the conf.xml file' do
       run_shell('cat /opt/apache-tomcat8/tomcat8/conf/server.xml') do |r|
-        r.stdout.should match(%r{<Valve className="org.apache.catalina.valves.AccessLogValve"><\/Valve>})
+        expect(r.stdout).to match(%r{<Valve className="org.apache.catalina.valves.AccessLogValve"><\/Valve>})
       end
     end
   end
@@ -195,7 +195,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
     end
     it 'has changed the conf.xml file' do
       run_shell('cat /opt/apache-tomcat8/tomcat8/conf/server.xml') do |r|
-        r.stdout.should_not match(%r{<Valve className="org.apache.catalina.valves.AccessLogValve"><\/Valve>})
+        expect(r.stdout).not_to match(%r{<Valve className="org.apache.catalina.valves.AccessLogValve"><\/Valve>})
       end
     end
   end
@@ -217,7 +217,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       # validation
       v = '<Service name="org.apache.catalina.core.StandardService" className="org.apache.catalina.core.StandardService"><Engine name="org.apache.catalina.core.StandardEngine" defaultHost="localhost" backgroundProcessorDelay="5" startStopThreads="3"><\/Engine>' # rubocop:disable Metrics/LineLength
       run_shell('cat /opt/apache-tomcat8/tomcat8/conf/server.xml') do |r|
-        r.stdout.should match(%r{#{v}})
+        expect(r.stdout).to match(%r{#{v}})
       end
     end
     pp_two = <<-MANIFEST
@@ -236,7 +236,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       # validation
       v = '<Service name="org.apache.catalina.core.StandardService" className="org.apache.catalina.core.StandardService"><Engine name="org.apache.catalina.core.StandardEngine" defaultHost="localhost" backgroundProcessorDelay="999" startStopThreads="555"><\/Engine>' # rubocop:disable Metrics/LineLength
       run_shell('cat /opt/apache-tomcat8/tomcat8/conf/server.xml') do |r|
-        r.stdout.should match(%r{#{v}})
+        expect(r.stdout).to match(%r{#{v}})
       end
     end
   end
@@ -261,7 +261,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
     it 'has changed the conf.xml file #joined' do
       run_shell('cat /opt/apache-tomcat8/tomcat8/conf/server.xml') do |r|
         matches.each do |m|
-          r.stdout.should match(%r{#{m}})
+          expect(r.stdout).to match(%r{#{m}})
         end
       end
     end
@@ -285,7 +285,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       # validation
       v = '<Host name="hulk-smash" appBase="/opt/apache-tomcat8/tomcat8/webapps" astrological_sign="scorpio"><\/Host>'
       run_shell('cat /opt/apache-tomcat8/tomcat8/conf/server.xml') do |r|
-        r.stdout.should match(%r{#{v}})
+        expect(r.stdout).to match(%r{#{v}})
       end
     end
   end
@@ -302,7 +302,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
     end
     it 'has changed the context.xml file' do
       run_shell('cat /opt/apache-tomcat8/tomcat8/conf/context.xml') do |r|
-        r.stdout.should match(%r{<Environment name="testEnvVar" type="java.lang.String" value="a value with a space"><\/Environment>})
+        expect(r.stdout).to match(%r{<Environment name="testEnvVar" type="java.lang.String" value="a value with a space"><\/Environment>})
       end
     end
   end
@@ -317,7 +317,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
     end
     it 'has changed the context.xml file' do
       run_shell('cat /opt/apache-tomcat8/tomcat8/conf/context.xml') do |r|
-        r.stdout.should match(%r{<Valve className="org.apache.catalina.valves.rewrite.RewriteValve"><\/Valve>})
+        expect(r.stdout).to match(%r{<Valve className="org.apache.catalina.valves.rewrite.RewriteValve"><\/Valve>})
       end
     end
   end

--- a/spec/acceptance/acceptance_4b_spec.rb
+++ b/spec/acceptance/acceptance_4b_spec.rb
@@ -79,8 +79,12 @@ describe 'Use two realms within a configuration', docker: true, unless: stop_tes
     end
     it 'contains two realms in config file', retry: 5, retry_wait: 10 do
       run_shell('cat /opt/apache-tomcat40/conf/server.xml') do |r|
-        r.stdout.should match(%r{<Realm puppetName="org.apache.catalina.realm.MyRealm1" className="org.apache.catalina.realm.MyRealm" resourceName="MyRealm1" otherAttribute="more stuff"><\/Realm>})
-        r.stdout.should match(%r{<Realm puppetName="org.apache.catalina.realm.MyRealm2" className="org.apache.catalina.realm.MyRealm" resourceName="MyRealm2" otherAttribute="more stuff"><\/Realm>})
+        expect(r.stdout).to match(
+          %r{<Realm puppetName="org.apache.catalina.realm.MyRealm1" className="org.apache.catalina.realm.MyRealm" resourceName="MyRealm1" otherAttribute="more stuff"><\/Realm>},
+        )
+        expect(r.stdout).to match(
+          %r{<Realm puppetName="org.apache.catalina.realm.MyRealm2" className="org.apache.catalina.realm.MyRealm" resourceName="MyRealm2" otherAttribute="more stuff"><\/Realm>},
+        )
       end
     end
     pp_two = <<-MANIFEST

--- a/spec/acceptance/readme_spec.rb
+++ b/spec/acceptance/readme_spec.rb
@@ -31,7 +31,7 @@ describe 'README examples', unless: stop_test do
     end
     it 'has the server running on port 8080' do
       run_shell('curl localhost:8080') do |r|
-        r.stdout.should match(%r{Apache Tomcat})
+        expect(r.stdout).to match(%r{Apache Tomcat})
       end
     end
   end

--- a/spec/defines/config/context/valve_spec.rb
+++ b/spec/defines/config/context/valve_spec.rb
@@ -26,9 +26,8 @@ describe 'tomcat::config::context::valve', type: :define do
     end
 
     changes = [
-      'set Context/Valve[#attribute/name=\'valve\']/#attribute/name valve',
-      'set Context/Valve[#attribute/name=\'valve\']/#attribute/className org.apache.catalina.valves.rewrite.RewriteValve',
-      'rm Context/Valve[#attribute/name=\'valve\']/#attribute/foobar',
+      'set Context/Valve[#attribute/className=\'org.apache.catalina.valves.rewrite.RewriteValve\']/#attribute/className org.apache.catalina.valves.rewrite.RewriteValve',
+      'rm Context/Valve[#attribute/className=\'org.apache.catalina.valves.rewrite.RewriteValve\']/#attribute/foobar',
     ]
     it {
       is_expected.to contain_augeas('context-/opt/apache-tomcat/test-valve-valve').with(
@@ -42,6 +41,7 @@ describe 'tomcat::config::context::valve', type: :define do
     let :params do
       {
         catalina_base: '/opt/apache-tomcat/test',
+        resource_type: 'org.apache.catalina.valves.rewrite.RewriteValve',
         ensure: 'absent',
       }
     end
@@ -50,7 +50,7 @@ describe 'tomcat::config::context::valve', type: :define do
       is_expected.to contain_augeas('context-/opt/apache-tomcat/test-valve-valve').with(
         'lens' => 'Xml.lns',
         'incl' => '/opt/apache-tomcat/test/conf/context.xml',
-        'changes' => ['rm Context/Valve[#attribute/name=\'valve\']'],
+        'changes' => ['rm Context/Valve[#attribute/className=\'org.apache.catalina.valves.rewrite.RewriteValve\']'],
       )
     }
   end

--- a/spec/defines/config/server/connector_spec.rb
+++ b/spec/defines/config/server/connector_spec.rb
@@ -185,7 +185,7 @@ describe 'tomcat::config::server::connector', type: :define do
       it do
         expect {
           catalogue
-        }.to raise_error(Puppet::Error)
+        }.to raise_error(Puppet::Error, %r{port must be specified})
       end
     end
     context 'old augeas' do


### PR DESCRIPTION
Attribute/Property 'name' is not valid for Context/Valve.
Fixes MODULES-10855