### PR TITLE
(IAC-1214) - Move SKIP_GCC to test file

### DIFF
--- a/spec/acceptance/acceptance_1b_spec.rb
+++ b/spec/acceptance/acceptance_1b_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper_acceptance'
 
+# puppetlabs-gcc doesn't work on sles
+SKIP_GCC = (os[:family] == 'sles')
 stop_test = (UNSUPPORTED_PLATFORMS.any? { |up| os[:family] == up } || SKIP_TOMCAT_8 || SKIP_GCC)
 
 describe 'Acceptance case one', unless: stop_test do

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -105,6 +105,3 @@ confine_8_array = [
 
 # Tomcat 8 needs java 1.7 or newer
 SKIP_TOMCAT_8 = confine_8_array.any?
-
-# puppetlabs-gcc doesn't work on Suse
-SKIP_GCC = (os[:family] == 'suse')


### PR DESCRIPTION
SKIP_GCC does not support SLES therefore acceptance_1b_spec.rb should not be ran against SLES. When setting SKIP_GCC in the spec_helper_acceptance_local.rb it was not returning `os[:family]` as expected. In order for this to work it needed moved to the test file and is now working and SKIP_GCC when ran on SLES is now returning true.