### PR TITLE
(IAC-1416) - commons-daemon-native new v1.2.4

### DIFF
--- a/spec/acceptance/acceptance_1b_spec.rb
+++ b/spec/acceptance/acceptance_1b_spec.rb
@@ -43,27 +43,27 @@ describe 'Acceptance case one', unless: stop_test do
             cleanup      => false,
             path         => "/opt/apache-tomcat/bin/commons-daemon-native.tar.gz",
             extract_path => "/opt/apache-tomcat/bin",
-            creates      => "/opt/apache-tomcat/bin/commons-daemon-1.2.3-native-src",
+            creates      => "/opt/apache-tomcat/bin/commons-daemon-1.2.4-native-src",
           }
           -> exec { 'configure jsvc':
             command  => "JAVA_HOME=${java_home} configure --with-java=${java_home}",
-            creates  => "/opt/apache-tomcat/bin/commons-daemon-1.2.3-native-src/unix/Makefile",
-            cwd      => "/opt/apache-tomcat/bin/commons-daemon-1.2.3-native-src/unix",
-            path     => "/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin:/opt/apache-tomcat/bin/commons-daemon-1.2.3-native-src/unix",
+            creates  => "/opt/apache-tomcat/bin/commons-daemon-1.2.4-native-src/unix/Makefile",
+            cwd      => "/opt/apache-tomcat/bin/commons-daemon-1.2.4-native-src/unix",
+            path     => "/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin:/opt/apache-tomcat/bin/commons-daemon-1.2.4-native-src/unix",
             require  => [ Class['gcc'], Class['java'] ],
             provider => shell,
           }
           -> exec { 'make jsvc':
             command  => 'make',
-            creates  => "/opt/apache-tomcat/bin/commons-daemon-1.2.3-native-src/unix/jsvc",
-            cwd      => "/opt/apache-tomcat/bin/commons-daemon-1.2.3-native-src/unix",
-            path     => "/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin:/opt/apache-tomcat/bin/commons-daemon-1.2.3-native-src/unix",
+            creates  => "/opt/apache-tomcat/bin/commons-daemon-1.2.4-native-src/unix/jsvc",
+            cwd      => "/opt/apache-tomcat/bin/commons-daemon-1.2.4-native-src/unix",
+            path     => "/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin:/opt/apache-tomcat/bin/commons-daemon-1.2.4-native-src/unix",
             provider => shell,
           }
           -> file { 'jsvc':
             ensure => link,
             path   => "/opt/apache-tomcat/bin/jsvc",
-            target => "/opt/apache-tomcat/bin/commons-daemon-1.2.3-native-src/unix/jsvc",
+            target => "/opt/apache-tomcat/bin/commons-daemon-1.2.4-native-src/unix/jsvc",
           }
         }
 


### PR DESCRIPTION
I observed that when `commons-daemon-native.tar.gz` is extracted the `commons-daemon-1.2.4-native-src` directory is created instead of the `commons-daemon-1.2.3-native-src` directory, as was before. This fact happening because the Tomcat Native Library was updated on the latest versions.
A simple solution is to adapt our acceptance tests to the new reality.