### PR TITLE
Add service_name parameter to tomcat::instance

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -43,6 +43,8 @@
 #   ```
 # @param copy_from_home_mode
 #   Specifies the file mode when copying the initial config files from `catalina_home` to `catalina_base`. Valid options: a string containing a standard Linux mode.
+# @param service_name
+#   Name of the service when managing the service
 # @param install_from_source
 #   Specifies whether or not the instance should be installed from source.
 # @param source_url
@@ -75,6 +77,7 @@ define tomcat::instance (
   $manage_copy_from_home  = true,
   $copy_from_home_list    = undef,
   $copy_from_home_mode    = '0660',
+  $service_name           = undef,
 
   #used for single installs. Deprecated.
   $install_from_source    = undef,
@@ -203,6 +206,7 @@ define tomcat::instance (
   }
   if $_manage_service {
     tomcat::service { $name:
+      service_name  => $service_name,
       catalina_home => $_catalina_home,
       catalina_base => $_catalina_base,
       java_home     => $java_home,

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -439,4 +439,20 @@ describe 'tomcat::instance', type: :define do
     it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/webapps') }
     it { is_expected.not_to contain_file('/opt/apache-tomcat/foo/work') }
   end
+  context 'manage service init with service_name' do
+    let :facts do
+      default_facts
+    end
+    let :params do
+      {
+        source_url: 'http://mirror.nexcess.net/apache/tomcat/tomcat-8/v8.0.8/bin/apache-tomcat-8.0.8.tar.gz',
+        manage_service: true,
+        use_jsvc: false,
+        use_init: true,
+        service_name: 'tomcat-default',
+      }
+    end
+
+    it { is_expected.to contain_service('tomcat-default') }
+  end
 end


### PR DESCRIPTION
Without this change this would fail:

```
tomcat::instance { 'xnat':
    manage_service => true,
    use_jsvc       => false,
    use_init       => true,
    source_url     => "https://downloads.apache.org/tomcat/tomcat-8/v${tomcat_version}/bin/apache-tomcat-${tomcat_version}.tar.gz",
    java_home      => $java::use_java_home,
}
```

The issue is `use_jsvc: false` and `use_init: true` requires `service_name` be set.