### PR TITLE
Fix nightly as tomcat7 is EOL

### DIFF
--- a/spec/acceptance/acceptance_2b_spec.rb
+++ b/spec/acceptance/acceptance_2b_spec.rb
@@ -85,7 +85,7 @@ describe 'Two different installations with two instances each of Tomcat 7 in the
 
       tomcat::install { 'tomcat7078':
         catalina_home  => '/opt/apache-tomcat7078',
-        source_url     => '#{TOMCAT_LEGACY_SOURCE}',
+        source_url     => '#{TOMCAT7_RECENT_SOURCE}',
         allow_insecure => true,
       }
       tomcat::instance { 'tomcat7078-first':

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -71,12 +71,11 @@ def latest_tomcat_tarball_url(version)
   "#{mirror_url}/tomcat/tomcat-#{version}/v#{latest_version}/bin/apache-tomcat-#{latest_version}.tar.gz"
 end
 
-latest7 = latest_tomcat_tarball_url('7')
 latest8 = latest_tomcat_tarball_url('8')
 latest9 = latest_tomcat_tarball_url('9')
-
-TOMCAT7_RECENT_VERSION = ENV['TOMCAT7_RECENT_VERSION'] || latest7
-TOMCAT7_RECENT_SOURCE = latest7
+TOMCAT_LEGACY_VERSION = ENV['TOMCAT_LEGACY_VERSION'] || '7.0.85'
+# Please note that these URLs are http and therefore insecure. To remedy this you can change them to https, although some additional work may be required to match the required protocols of the server.
+TOMCAT7_RECENT_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-7/v#{TOMCAT_LEGACY_VERSION}/bin/apache-tomcat-#{TOMCAT_LEGACY_VERSION}.tar.gz"
 puts "TOMCAT7_RECENT_SOURCE is #{TOMCAT7_RECENT_SOURCE.inspect}"
 
 TOMCAT8_RECENT_VERSION = ENV['TOMCAT8_RECENT_VERSION'] || latest8
@@ -87,9 +86,6 @@ TOMCAT9_RECENT_VERSION = ENV['TOMCAT9_RECENT_VERSION'] || latest9
 TOMCAT9_RECENT_SOURCE = latest9
 puts "TOMCAT9_RECENT_SOURCE is #{TOMCAT9_RECENT_SOURCE.inspect}"
 
-TOMCAT_LEGACY_VERSION = ENV['TOMCAT_LEGACY_VERSION'] || '7.0.85'
-# Please note that these URLs are http and therefore insecure. To remedy this you can change them to https, although some additional work may be required to match the required protocols of the server.
-TOMCAT_LEGACY_SOURCE = "http://archive.apache.org/dist/tomcat/tomcat-7/v#{TOMCAT_LEGACY_VERSION}/bin/apache-tomcat-#{TOMCAT_LEGACY_VERSION}.tar.gz"
 SAMPLE_WAR = 'http://tomcat.apache.org/tomcat-9.0-doc/appdev/sample/sample.war'
 
 confine_8_array = [


### PR DESCRIPTION
This is a small workaround created to fix the nightly build until the PR for removing tomcat7 is ready