### PR TITLE
Update puppet-archive dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 1.0.0 < 5.0.0"
+      "version_requirement": ">= 1.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The version constraint is currently for archive < 5, which doesn't support Puppet 7, and blocks module updates when using librarian-puppet to resolve dependency versions.