### PR TITLE
pdksync - (CONT-130) - Dropping Support for Debian 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -55,7 +55,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
         "10",
         "11"
       ]


### PR DESCRIPTION
(CONT-130) - Dropping Support for Debian 9
pdk version: `2.4.0` 
