### PR TITLE
Exclude name in resources

### DIFF
--- a/manifests/config/context/resources.pp
+++ b/manifests/config/context/resources.pp
@@ -36,13 +36,12 @@ define tomcat::config::context::resources (
     $_resources_name = $name
   }
 
-  $base_path = "Context/Resources[#attribute/name='${_resources_name}']"
+  $base_path = "Context/Resources[#attribute]"
 
   if $ensure == 'absent' {
     $changes = "rm ${base_path}"
   } else {
     # (MODULES-3353) does this need to be quoted?
-    $set_name = "set ${base_path}/#attribute/name ${_resources_name}"
     if $resources_type {
       $set_type = "set ${base_path}/#attribute/type ${resources_type}"
     } else {

--- a/manifests/config/context/resources.pp
+++ b/manifests/config/context/resources.pp
@@ -2,12 +2,6 @@
 #
 # @param ensure
 #   Specifies whether you are trying to add or remove the Resources element.
-# @param resources_name
-#   The name of the Resources to be created, relative to the `java:comp/env` context. `$name`.
-# @param name
-#   `$resources_name`
-# @param resources_type
-#   The fully qualified Java class name expected by the web application when it performs a lookup for this resources. Required to create the resource.
 # @param catalina_base
 #   Specifies the root of the Tomcat installation.
 # @param additional_attributes
@@ -19,8 +13,6 @@
 #
 define tomcat::config::context::resources (
   Enum['present','absent'] $ensure = 'present',
-  $resources_name                  = $name,
-  $resources_type                  = undef,
   $catalina_base                   = $::tomcat::catalina_home,
   Hash $additional_attributes      = {},
   Array $attributes_to_remove      = [],
@@ -30,24 +22,11 @@ define tomcat::config::context::resources (
     fail('Server configurations require Augeas >= 1.0.0')
   }
 
-  if $resources_name {
-    $_resources_name = $resources_name
-  } else {
-    $_resources_name = $name
-  }
-
   $base_path = "Context/Resources[#attribute]"
 
   if $ensure == 'absent' {
     $changes = "rm ${base_path}"
   } else {
-    # (MODULES-3353) does this need to be quoted?
-    if $resources_type {
-      $set_type = "set ${base_path}/#attribute/type ${resources_type}"
-    } else {
-      $set_type = undef
-    }
-
     if ! empty($additional_attributes) {
       $set_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${base_path}/#attribute/"), "'")
     } else {
@@ -60,8 +39,6 @@ define tomcat::config::context::resources (
     }
 
     $changes = delete_undef_values(flatten([
-          $set_name,
-          $set_type,
           $set_additional_attributes,
           $rm_attributes_to_remove,
     ]))

--- a/spec/defines/config/context/resources_spec.rb
+++ b/spec/defines/config/context/resources_spec.rb
@@ -13,14 +13,13 @@ describe 'tomcat::config::context::resources', type: :define do
     }
   end
   let :title do
-    'jdbc'
+    'attributes'
   end
 
   context 'Add Resources' do
     let :params do
       {
         catalina_base: '/opt/apache-tomcat/test',
-        resources_type: 'net.sourceforge.jtds.jdbcx.JtdsDataSource',
         additional_attributes: {
           'cachingAllowed'  => 'true',
           'cacheMaxSize'    => '100000',
@@ -32,20 +31,19 @@ describe 'tomcat::config::context::resources', type: :define do
     end
 
     changes = [
-      'set Context/Resources[#attribute/name=\'jdbc\']/#attribute/name jdbc',
-      'set Context/Resources[#attribute/name=\'jdbc\']/#attribute/type net.sourceforge.jtds.jdbcx.JtdsDataSource',
-      'set Context/Resources[#attribute/name=\'jdbc\']/#attribute/cachingAllowed \'true\'',
-      'set Context/Resources[#attribute/name=\'jdbc\']/#attribute/cacheMaxSize \'100000\'',
-      'rm Context/Resources[#attribute/name=\'jdbc\']/#attribute/foobar',
+      'set Context/Resources[#attribute]/#attribute/cachingAllowed \'true\'',
+      'set Context/Resources[#attribute]/#attribute/cacheMaxSize \'100000\'',
+      'rm Context/Resources[#attribute]/#attribute/foobar',
     ]
     it {
-      is_expected.to contain_augeas('context-/opt/apache-tomcat/test-resources-jdbc').with(
+      is_expected.to contain_augeas('context-/opt/apache-tomcat/test-resources-attributes').with(
         'lens' => 'Xml.lns',
         'incl' => '/opt/apache-tomcat/test/conf/context.xml',
         'changes' => changes,
       )
     }
   end
+
   context 'Remove Resources' do
     let :params do
       {
@@ -55,10 +53,10 @@ describe 'tomcat::config::context::resources', type: :define do
     end
 
     it {
-      is_expected.to contain_augeas('context-/opt/apache-tomcat/test-resources-jdbc').with(
+      is_expected.to contain_augeas('context-/opt/apache-tomcat/test-resources-attributes').with(
         'lens' => 'Xml.lns',
         'incl' => '/opt/apache-tomcat/test/conf/context.xml',
-        'changes' => ['rm Context/Resources[#attribute/name=\'jdbc\']'],
+        'changes' => ['rm Context/Resources[#attribute]'],
       )
     }
   end


### PR DESCRIPTION
Fixes #499

According to https://tomcat.apache.org/tomcat-9.0-doc/config/resources.html, name and type are not part of the Resources block