### PR TITLE
Allow adding and removing attributes  in Context (#502)

### DIFF
--- a/manifests/config/context.pp
+++ b/manifests/config/context.pp
@@ -29,7 +29,7 @@ define tomcat::config::context (
     $set_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${base_path}/#attribute/"), "'")
 
     # Extra augeas to add atttibutes if there are currently no attrributes in <Context> element
-    augeas{ "context-add_attribute_${_catalina_base}":
+    augeas { "context-add_attribute_${_catalina_base}":
       incl    => "${catalina_base}/conf/context.xml",
       lens    => 'Xml.lns',
       context => "/files/${catalina_base}/conf/context.xml",
@@ -62,5 +62,3 @@ define tomcat::config::context (
     }
   }
 }
-
-

--- a/manifests/config/context.pp
+++ b/manifests/config/context.pp
@@ -2,12 +2,18 @@
 #
 # @param catalina_base
 #   Specifies the root of the Tomcat installation.
+# @param additional_attributes
+#   Specifies any additional attributes to add to the Context. Should be a hash of the format 'attribute' => 'value'. Optional
+# @param attributes_to_remove
+#   Specifies an array of attributes to remove from the element. Valid options: an array of strings. `[]`.
 # @param show_diff
 #   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::context (
-  $catalina_base     = undef,
-  Boolean $show_diff = true,
+  $catalina_base               = undef,
+  Hash $additional_attributes  = {},
+  Array $attributes_to_remove  = [],
+  Boolean $show_diff           = true,
 ) {
   include ::tomcat
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
@@ -17,9 +23,35 @@ define tomcat::config::context (
     fail('Server configurations require Augeas >= 1.0.0')
   }
 
+  $base_path = 'Context'
+
+  if ! empty($additional_attributes) {
+    $set_additional_attributes = suffix(prefix(join_keys_to_values($additional_attributes, " '"), "set ${base_path}/#attribute/"), "'")
+
+    # Extra augeas to add atttibutes if there are currently no attrributes in <Context> element
+    augeas{ "context-add_attribute_${_catalina_base}":
+      incl    => "${catalina_base}/conf/context.xml",
+      lens    => 'Xml.lns',
+      context => "/files/${catalina_base}/conf/context.xml",
+      changes => ['ins #attribute before Context/#text[1]'] + $set_additional_attributes,
+      onlyif  => 'match Context/#attribute size == 0',
+    }
+  } else {
+    $set_additional_attributes = undef
+  }
+  if ! empty(any2array($attributes_to_remove)) {
+    $rm_attributes_to_remove = prefix(any2array($attributes_to_remove), "rm ${base_path}/#attribute/")
+  } else {
+    $rm_attributes_to_remove = undef
+  }
+
   $_watched_resource = 'set Context/WatchedResource/#text "WEB-INF/web.xml"'
 
-  $changes = delete_undef_values([$_watched_resource])
+  $changes = delete_undef_values(flatten([
+        $_watched_resource,
+        $set_additional_attributes,
+        $rm_attributes_to_remove,
+  ]))
 
   if ! empty($changes) {
     augeas { "context-${_catalina_base}":
@@ -30,3 +62,5 @@ define tomcat::config::context (
     }
   }
 }
+
+

--- a/spec/acceptance/acceptance_1b_spec.rb
+++ b/spec/acceptance/acceptance_1b_spec.rb
@@ -27,7 +27,7 @@ describe 'Acceptance case one', unless: stop_test do
     end
   end
 
-  let(:daemon_version) { '1.3.2' }
+  let(:daemon_version) { '1.3.3' }
 
   context 'Initial install Tomcat and verification' do
     it 'applies the manifest without error' do

--- a/spec/defines/config/context_spec.rb
+++ b/spec/defines/config/context_spec.rb
@@ -32,6 +32,32 @@ describe 'tomcat::config::context', type: :define do
     }
   end
 
+  context 'Add Attribute' do
+    let :params do
+      {
+        catalina_base: '/opt/apache-tomcat/test',
+        additional_attributes: {
+          'crossContext'    => 'true',
+        },
+        attributes_to_remove: [
+          'foobar',
+        ],
+      }
+    end
+
+    changes = [
+      'set Context/WatchedResource/#text "WEB-INF/web.xml"',
+      'set Context/#attribute/crossContext \'true\'',
+      'rm Context/#attribute/foobar',
+    ]
+    it {
+      is_expected.to contain_augeas('context-/opt/apache-tomcat/test').with(
+        'lens' => 'Xml.lns',
+        'incl' => '/opt/apache-tomcat/test/conf/context.xml',
+        'changes' => changes,
+      )
+    }
+  end
   describe 'failing tests' do
     context 'old augeas' do
       let :facts do

--- a/spec/defines/config/context_spec.rb
+++ b/spec/defines/config/context_spec.rb
@@ -37,7 +37,7 @@ describe 'tomcat::config::context', type: :define do
       {
         catalina_base: '/opt/apache-tomcat/test',
         additional_attributes: {
-          'crossContext'    => 'true',
+          'crossContext' => 'true',
         },
         attributes_to_remove: [
           'foobar',


### PR DESCRIPTION
Fixes #502 

A bit of a hack with an extra augeas was required to add attributes in <Context> element if there are no existing attributes.

This is my first puppet module pull request so apologies if I've got anything wrong.

Thanks!