### PR TITLE
pdksync - (CONT-494) Pin github_changelog_generator and JSON gem versions

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -46,3 +46,4 @@ Gemfile:
       version: '= 0.4.5'
       platforms: ruby
     - gem: github_changelog_generator
+      version: '= 1.15.2'

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,12 @@ def location_for(place_or_version, fake_version = nil)
 end
 
 group :development do
-  gem "json", '~> 2.0',                                require: false
-  gem "voxpupuli-puppet-lint-plugins", '~> 3.0',       require: false
+  gem "json", '= 2.1.0',                               require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                               require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                               require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                               require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                               require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "voxpupuli-puppet-lint-plugins", '~> 3.1',       require: false
   gem "facterdb", '~> 1.18',                           require: false
   gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0',     require: false
   gem "puppetlabs_spec_helper", '>= 3.0.0', '< 5.0.0', require: false
@@ -31,7 +35,7 @@ group :development do
   gem "rubocop-rspec", '= 2.0.1',                      require: false
   gem "rb-readline", '= 0.5.5',                        require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "rspec-retry", '= 0.4.5',                        require: false, platforms: [:ruby]
-  gem "github_changelog_generator",                    require: false
+  gem "github_changelog_generator", '= 1.15.2',        require: false
 end
 group :system_tests do
   gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby]

--- a/metadata.json
+++ b/metadata.json
@@ -91,6 +91,6 @@
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "tags/2.6.0-0-gd0490b9",
+  "template-ref": "2.7.1-0-g9a16c87",
   "pdk-version": "2.5.0"
 }


### PR DESCRIPTION
CONT-494/pin_github_changelog_generator
pdk version: `2.5.0` 
