### PR TITLE
Drop legacy facts

### DIFF
--- a/manifests/config/context.pp
+++ b/manifests/config/context.pp
@@ -13,7 +13,7 @@ define tomcat::config::context (
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
   tag(sha1($_catalina_base))
 
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/context/environment.pp
+++ b/manifests/config/context/environment.pp
@@ -35,7 +35,7 @@ define tomcat::config::context::environment (
   Array $attributes_to_remove         = [],
   Boolean $show_diff                  = true,
 ) {
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/context/manager.pp
+++ b/manifests/config/context/manager.pp
@@ -23,7 +23,7 @@ define tomcat::config::context::manager (
   Array $attributes_to_remove      = [],
   Boolean $show_diff               = true,
 ) {
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/context/parameter.pp
+++ b/manifests/config/context/parameter.pp
@@ -22,7 +22,7 @@ define tomcat::config::context::parameter (
   Optional[String]                            $description    = undef,
   Optional[Boolean]                           $override       = undef,
 ) {
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/context/resource.pp
+++ b/manifests/config/context/resource.pp
@@ -26,7 +26,7 @@ define tomcat::config::context::resource (
   Array $attributes_to_remove      = [],
   Boolean $show_diff               = true,
 ) {
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/context/resourcelink.pp
+++ b/manifests/config/context/resourcelink.pp
@@ -26,7 +26,7 @@ define tomcat::config::context::resourcelink (
   Array $attributes_to_remove      = [],
   Boolean $show_diff               = true,
 ) {
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Context configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/context/resources.pp
+++ b/manifests/config/context/resources.pp
@@ -18,7 +18,7 @@ define tomcat::config::context::resources (
   Array $attributes_to_remove      = [],
   Boolean $show_diff               = true,
 ) {
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/context/valve.pp
+++ b/manifests/config/context/valve.pp
@@ -36,7 +36,7 @@ define tomcat::config::context::valve (
   Array $uniqueness_attributes     = [],
   Boolean $show_diff               = true,
 ) {
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Valve configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/server.pp
+++ b/manifests/config/server.pp
@@ -34,7 +34,7 @@ define tomcat::config::server (
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
   tag(sha1($_catalina_base))
 
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/server/connector.pp
+++ b/manifests/config/server/connector.pp
@@ -39,7 +39,7 @@ define tomcat::config::server::connector (
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
   tag(sha1($_catalina_base))
   $_purge_connectors = pick($purge_connectors, $::tomcat::purge_connectors)
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/server/context.pp
+++ b/manifests/config/server/context.pp
@@ -37,7 +37,7 @@ define tomcat::config::server::context (
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
   tag(sha1($_catalina_base))
 
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/server/engine.pp
+++ b/manifests/config/server/engine.pp
@@ -49,7 +49,7 @@ define tomcat::config::server::engine (
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
   tag(sha1($_catalina_base))
 
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/server/globalnamingresource.pp
+++ b/manifests/config/server/globalnamingresource.pp
@@ -27,7 +27,7 @@ define tomcat::config::server::globalnamingresource (
   $server_config                   = undef,
   Boolean $show_diff               = true,
 ) {
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/server/host.pp
+++ b/manifests/config/server/host.pp
@@ -37,7 +37,7 @@ define tomcat::config::server::host (
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
   tag(sha1($_catalina_base))
 
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/server/listener.pp
+++ b/manifests/config/server/listener.pp
@@ -33,7 +33,7 @@ define tomcat::config::server::listener (
   $server_config                            = undef,
   Boolean $show_diff                        = true,
 ) {
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/server/realm.pp
+++ b/manifests/config/server/realm.pp
@@ -46,7 +46,7 @@ define tomcat::config::server::realm (
   tag(sha1($_catalina_base))
   $_purge_realms = pick($purge_realms, $::tomcat::purge_realms)
 
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/server/resources.pp
+++ b/manifests/config/server/resources.pp
@@ -37,7 +37,7 @@ define tomcat::config::server::resources (
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
   tag(sha1($_catalina_base))
 
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/server/service.pp
+++ b/manifests/config/server/service.pp
@@ -25,7 +25,7 @@ define tomcat::config::server::service (
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
   tag(sha1($_catalina_base))
 
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/server/tomcat_users.pp
+++ b/manifests/config/server/tomcat_users.pp
@@ -36,7 +36,7 @@ define tomcat::config::server::tomcat_users (
   Array $roles                     = [],
   Boolean $show_diff               = true,
 ) {
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/config/server/valve.pp
+++ b/manifests/config/server/valve.pp
@@ -40,7 +40,7 @@ define tomcat::config::server::valve (
   $_catalina_base = pick($catalina_base, $::tomcat::catalina_home)
   tag(sha1($_catalina_base))
 
-  if versioncmp($::augeasversion, '1.0.0') < 0 {
+  if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Valve configurations require Augeas >= 1.0.0')
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,9 +33,9 @@ class tomcat (
   Boolean $manage_base       = true,
   Boolean $manage_properties = true,
 ) {
-  case $::osfamily {
+  case $facts['os']['family'] {
     'windows','Solaris','Darwin': {
-      fail("Unsupported osfamily: ${::osfamily}")
+      fail("Unsupported os family: ${facts['os']['family']}")
     }
     default: {
       # Empty

--- a/spec/acceptance/acceptance_1b_spec.rb
+++ b/spec/acceptance/acceptance_1b_spec.rb
@@ -16,9 +16,9 @@ describe 'Acceptance case one', unless: stop_test do
   let :java_home do
     if os[:family].match?(%r{debian|ubuntu})
       if os[:release].start_with?('9')
-        '"/usr/lib/jvm/java-8-openjdk-${::architecture}"'
+        '"/usr/lib/jvm/java-8-openjdk-${facts[\'os\'][\'architecture\']}"'
       else
-        '"/usr/lib/jvm/java-11-openjdk-${::architecture}"'
+        '"/usr/lib/jvm/java-11-openjdk-${facts[\'os\'][\'architecture\']}"'
       end
     elsif os[:family].include?('redhat')
       '"/etc/alternatives/java_sdk"'

--- a/spec/acceptance/acceptance_1b_spec.rb
+++ b/spec/acceptance/acceptance_1b_spec.rb
@@ -27,7 +27,7 @@ describe 'Acceptance case one', unless: stop_test do
     end
   end
 
-  let(:daemon_version) { '1.3.2' }
+  let(:daemon_version) { '1.3.3' }
 
   context 'Initial install Tomcat and verification' do
     it 'applies the manifest without error' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,7 +4,9 @@ require 'spec_helper'
 describe 'tomcat' do
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
     }
   end
 

--- a/spec/classes/tomcat_spec.rb
+++ b/spec/classes/tomcat_spec.rb
@@ -6,7 +6,9 @@ describe 'tomcat', type: :class do
   context 'not installing from source' do
     let :facts do
       {
-        osfamily: 'Debian',
+        os: {
+          family: 'Debian',
+        },
       }
     end
     let :params do
@@ -20,7 +22,9 @@ describe 'tomcat', type: :class do
   context 'not managing user/group' do
     let :facts do
       {
-        osfamily: 'Debian',
+        os: {
+          family: 'Debian',
+        },
       }
     end
     let :params do
@@ -37,7 +41,9 @@ describe 'tomcat', type: :class do
   context 'with invalid $manage_user' do
     let :facts do
       {
-        osfamily: 'Debian',
+        os: {
+          family: 'Debian',
+        },
       }
     end
     let :params do
@@ -56,40 +62,46 @@ describe 'tomcat', type: :class do
   context 'on windows' do
     let :facts do
       {
-        osfamily: 'windows',
+        os: {
+          family: 'windows',
+        },
       }
     end
 
     it do
       expect {
         catalogue
-      }.to raise_error(Puppet::Error, %r{Unsupported osfamily})
+      }.to raise_error(Puppet::Error, %r{Unsupported os family})
     end
   end
   context 'on Solaris' do
     let :facts do
       {
-        osfamily: 'Solaris',
+        os: {
+          family: 'Solaris',
+        },
       }
     end
 
     it do
       expect {
         catalogue
-      }.to raise_error(Puppet::Error, %r{Unsupported osfamily})
+      }.to raise_error(Puppet::Error, %r{Unsupported os family})
     end
   end
   context 'on OSX' do
     let :facts do
       {
-        osfamily: 'Darwin',
+        os: {
+          family: 'Darwin',
+        },
       }
     end
 
     it do
       expect {
         catalogue
-      }.to raise_error(Puppet::Error, %r{Unsupported osfamily})
+      }.to raise_error(Puppet::Error, %r{Unsupported os family})
     end
   end
 end

--- a/spec/defines/config/context/environment_spec.rb
+++ b/spec/defines/config/context/environment_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::context::environment', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },

--- a/spec/defines/config/context/environment_spec.rb
+++ b/spec/defines/config/context/environment_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::context::environment', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do

--- a/spec/defines/config/context/manager_spec.rb
+++ b/spec/defines/config/context/manager_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::context::manager', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do

--- a/spec/defines/config/context/manager_spec.rb
+++ b/spec/defines/config/context/manager_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::context::manager', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },

--- a/spec/defines/config/context/parameter_spec.rb
+++ b/spec/defines/config/context/parameter_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::context::parameter', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },

--- a/spec/defines/config/context/parameter_spec.rb
+++ b/spec/defines/config/context/parameter_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::context::parameter', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
 

--- a/spec/defines/config/context/resource_spec.rb
+++ b/spec/defines/config/context/resource_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::context::resource', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },

--- a/spec/defines/config/context/resource_spec.rb
+++ b/spec/defines/config/context/resource_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::context::resource', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do

--- a/spec/defines/config/context/resourcelink_spec.rb
+++ b/spec/defines/config/context/resourcelink_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::context::resourcelink', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },

--- a/spec/defines/config/context/resourcelink_spec.rb
+++ b/spec/defines/config/context/resourcelink_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::context::resourcelink', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do

--- a/spec/defines/config/context/resources_spec.rb
+++ b/spec/defines/config/context/resources_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::context::resources', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },

--- a/spec/defines/config/context/resources_spec.rb
+++ b/spec/defines/config/context/resources_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::context::resources', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do

--- a/spec/defines/config/context/valve_spec.rb
+++ b/spec/defines/config/context/valve_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::context::valve', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },
@@ -146,7 +148,9 @@ describe 'tomcat::config::context::valve', type: :define do
     context 'old augeas' do
       let :facts do
         {
-          osfamily: 'Debian',
+          os: {
+            family: 'Debian',
+          },
           augeas: {
             version: '0.10.0',
           },

--- a/spec/defines/config/context/valve_spec.rb
+++ b/spec/defines/config/context/valve_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::context::valve', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
 
@@ -145,7 +147,9 @@ describe 'tomcat::config::context::valve', type: :define do
       let :facts do
         {
           osfamily: 'Debian',
-          augeasversion: '0.10.0',
+          augeas: {
+            version: '0.10.0',
+          },
         }
       end
 

--- a/spec/defines/config/context_spec.rb
+++ b/spec/defines/config/context_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::context', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },
@@ -38,7 +40,9 @@ describe 'tomcat::config::context', type: :define do
     context 'old augeas' do
       let :facts do
         {
-          osfamily: 'Debian',
+          os: {
+            family: 'Debian',
+          },
           augeas: {
             version: '0.10.0',
           },

--- a/spec/defines/config/context_spec.rb
+++ b/spec/defines/config/context_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::context', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do
@@ -37,7 +39,9 @@ describe 'tomcat::config::context', type: :define do
       let :facts do
         {
           osfamily: 'Debian',
-          augeasversion: '0.10.0',
+          augeas: {
+            version: '0.10.0',
+          },
         }
       end
 

--- a/spec/defines/config/server/connector_spec.rb
+++ b/spec/defines/config/server/connector_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::server::connector', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do
@@ -194,7 +196,9 @@ describe 'tomcat::config::server::connector', type: :define do
       let :facts do
         {
           osfamily: 'Debian',
-          augeasversion: '0.10.0',
+          augeas: {
+            version: '0.10.0',
+          },
         }
       end
 

--- a/spec/defines/config/server/connector_spec.rb
+++ b/spec/defines/config/server/connector_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::server::connector', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },
@@ -195,7 +197,9 @@ describe 'tomcat::config::server::connector', type: :define do
     context 'old augeas' do
       let :facts do
         {
-          osfamily: 'Debian',
+          os: {
+            family: 'Debian',
+          },
           augeas: {
             version: '0.10.0',
           },

--- a/spec/defines/config/server/context_spec.rb
+++ b/spec/defines/config/server/context_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::server::context', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },
@@ -197,7 +199,9 @@ describe 'tomcat::config::server::context', type: :define do
     context 'old augeas' do
       let :facts do
         {
-          osfamily: 'Debian',
+          os: {
+            family: 'Debian',
+          },
           augeas: {
             version: '0.10.0',
           },

--- a/spec/defines/config/server/context_spec.rb
+++ b/spec/defines/config/server/context_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::server::context', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do
@@ -196,7 +198,9 @@ describe 'tomcat::config::server::context', type: :define do
       let :facts do
         {
           osfamily: 'Debian',
-          augeasversion: '0.10.0',
+          augeas: {
+            version: '0.10.0',
+          },
         }
       end
 

--- a/spec/defines/config/server/engine_spec.rb
+++ b/spec/defines/config/server/engine_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::server::engine', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },
@@ -155,7 +157,9 @@ describe 'tomcat::config::server::engine', type: :define do
     context 'old augeas' do
       let :facts do
         {
-          osfamily: 'Debian',
+          os: {
+            family: 'Debian',
+          },
           augeas: {
             version: '0.10.0',
           },

--- a/spec/defines/config/server/engine_spec.rb
+++ b/spec/defines/config/server/engine_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::server::engine', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do
@@ -154,7 +156,9 @@ describe 'tomcat::config::server::engine', type: :define do
       let :facts do
         {
           osfamily: 'Debian',
-          augeasversion: '0.10.0',
+          augeas: {
+            version: '0.10.0',
+          },
         }
       end
       let :params do

--- a/spec/defines/config/server/globalnamingresource_spec.rb
+++ b/spec/defines/config/server/globalnamingresource_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::server::globalnamingresource', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },

--- a/spec/defines/config/server/globalnamingresource_spec.rb
+++ b/spec/defines/config/server/globalnamingresource_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::server::globalnamingresource', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do

--- a/spec/defines/config/server/host_spec.rb
+++ b/spec/defines/config/server/host_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::server::host', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },
@@ -165,7 +167,9 @@ describe 'tomcat::config::server::host', type: :define do
     context 'old augeas' do
       let :facts do
         {
-          osfamily: 'Debian',
+          os: {
+            family: 'Debian',
+          },
           augeas: {
             version: '0.10.0',
           },

--- a/spec/defines/config/server/host_spec.rb
+++ b/spec/defines/config/server/host_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::server::host', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do
@@ -164,7 +166,9 @@ describe 'tomcat::config::server::host', type: :define do
       let :facts do
         {
           osfamily: 'Debian',
-          augeasversion: '0.10.0',
+          augeas: {
+            version: '0.10.0',
+          },
         }
       end
 

--- a/spec/defines/config/server/listener_spec.rb
+++ b/spec/defines/config/server/listener_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::server::listener', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },
@@ -224,7 +226,9 @@ describe 'tomcat::config::server::listener', type: :define do
     context 'old augeas' do
       let :facts do
         {
-          osfamily: 'Debian',
+          os: {
+            family: 'Debian',
+          },
           augeas: {
             version: '0.10.0',
           },

--- a/spec/defines/config/server/listener_spec.rb
+++ b/spec/defines/config/server/listener_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::server::listener', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do
@@ -223,7 +225,9 @@ describe 'tomcat::config::server::listener', type: :define do
       let :facts do
         {
           osfamily: 'Debian',
-          augeasversion: '0.10.0',
+          augeas: {
+            version: '0.10.0',
+          },
         }
       end
 

--- a/spec/defines/config/server/realm_spec.rb
+++ b/spec/defines/config/server/realm_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::server::realm', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },
@@ -439,7 +441,9 @@ describe 'tomcat::config::server::realm', type: :define do
     context 'old augeas' do
       let :facts do
         {
-          osfamily: 'Debian',
+          os: {
+            family: 'Debian',
+          },
           augeas: {
             version: '0.10.0',
           },

--- a/spec/defines/config/server/realm_spec.rb
+++ b/spec/defines/config/server/realm_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::server::realm', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do
@@ -438,7 +440,9 @@ describe 'tomcat::config::server::realm', type: :define do
       let :facts do
         {
           osfamily: 'Debian',
-          augeasversion: '0.10.0',
+          augeas: {
+            version: '0.10.0',
+          },
         }
       end
 

--- a/spec/defines/config/server/resources_spec.rb
+++ b/spec/defines/config/server/resources_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::server::resources', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do
@@ -205,7 +207,9 @@ describe 'tomcat::config::server::resources', type: :define do
       let :facts do
         {
           osfamily: 'Debian',
-          augeasversion: '0.10.0',
+          augeas: {
+            version: '0.10.0',
+          },
         }
       end
 

--- a/spec/defines/config/server/resources_spec.rb
+++ b/spec/defines/config/server/resources_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::server::resources', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },
@@ -206,7 +208,9 @@ describe 'tomcat::config::server::resources', type: :define do
     context 'old augeas' do
       let :facts do
         {
-          osfamily: 'Debian',
+          os: {
+            family: 'Debian',
+          },
           augeas: {
             version: '0.10.0',
           },

--- a/spec/defines/config/server/service_spec.rb
+++ b/spec/defines/config/server/service_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::server::service', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },
@@ -127,7 +129,9 @@ describe 'tomcat::config::server::service', type: :define do
     context 'old augeas' do
       let :facts do
         {
-          osfamily: 'Debian',
+          os: {
+            family: 'Debian',
+          },
           augeas: {
             version: '0.10.0',
           },

--- a/spec/defines/config/server/service_spec.rb
+++ b/spec/defines/config/server/service_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::server::service', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do
@@ -126,7 +128,9 @@ describe 'tomcat::config::server::service', type: :define do
       let :facts do
         {
           osfamily: 'Debian',
-          augeasversion: '0.10.0',
+          augeas: {
+            version: '0.10.0',
+          },
         }
       end
 

--- a/spec/defines/config/server/tomcat_users_spec.rb
+++ b/spec/defines/config/server/tomcat_users_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::server::tomcat_users', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },
@@ -233,7 +235,9 @@ describe 'tomcat::config::server::tomcat_users', type: :define do
     context 'old augeas' do
       let :facts do
         {
-          osfamily: 'Debian',
+          os: {
+            family: 'Debian',
+          },
           augeas: {
             version: '0.10.0',
           },

--- a/spec/defines/config/server/tomcat_users_spec.rb
+++ b/spec/defines/config/server/tomcat_users_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::server::tomcat_users', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do
@@ -232,7 +234,9 @@ describe 'tomcat::config::server::tomcat_users', type: :define do
       let :facts do
         {
           osfamily: 'Debian',
-          augeasversion: '0.10.0',
+          augeas: {
+            version: '0.10.0',
+          },
         }
       end
 

--- a/spec/defines/config/server/valve_spec.rb
+++ b/spec/defines/config/server/valve_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::server::valve', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
 
@@ -120,7 +122,9 @@ describe 'tomcat::config::server::valve', type: :define do
       let :facts do
         {
           osfamily: 'Debian',
-          augeasversion: '0.10.0',
+          augeas: {
+            version: '0.10.0',
+          },
         }
       end
 

--- a/spec/defines/config/server/valve_spec.rb
+++ b/spec/defines/config/server/valve_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::server::valve', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },
@@ -121,7 +123,9 @@ describe 'tomcat::config::server::valve', type: :define do
     context 'old augeas' do
       let :facts do
         {
-          osfamily: 'Debian',
+          os: {
+            family: 'Debian',
+          },
           augeas: {
             version: '0.10.0',
           },

--- a/spec/defines/config/server_spec.rb
+++ b/spec/defines/config/server_spec.rb
@@ -9,7 +9,9 @@ describe 'tomcat::config::server', type: :define do
   let :facts do
     {
       osfamily: 'Debian',
-      augeasversion: '1.0.0',
+      augeas: {
+        version: '1.0.0',
+      },
     }
   end
   let :title do
@@ -128,7 +130,9 @@ describe 'tomcat::config::server', type: :define do
       let :facts do
         {
           osfamily: 'Debian',
-          augeasversion: '0.10.0',
+          augeas: {
+            version: '0.10.0',
+          },
         }
       end
 

--- a/spec/defines/config/server_spec.rb
+++ b/spec/defines/config/server_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::config::server', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       augeas: {
         version: '1.0.0',
       },
@@ -129,7 +131,9 @@ describe 'tomcat::config::server', type: :define do
     context 'old augeas' do
       let :facts do
         {
-          osfamily: 'Debian',
+          os: {
+            family: 'Debian',
+          },
           augeas: {
             version: '0.10.0',
           },

--- a/spec/defines/install_spec.rb
+++ b/spec/defines/install_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::install', type: :define do
   end
   let :default_facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     }
   end

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::instance', type: :define do
   end
   let :default_facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     }
   end

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::service', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
     }
   end
   let :title do

--- a/spec/defines/setenv/entry_spec.rb
+++ b/spec/defines/setenv/entry_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::setenv::entry', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
       concat_basedir: '/tmp',
       id: 'root',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',

--- a/spec/defines/war_spec.rb
+++ b/spec/defines/war_spec.rb
@@ -8,7 +8,9 @@ describe 'tomcat::war', type: :define do
   end
   let :facts do
     {
-      osfamily: 'Debian',
+      os: {
+        family: 'Debian',
+      },
     }
   end
   let :title do

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -28,7 +28,7 @@ RSpec.configure do |c|
       package { 'curl':
         ensure   => 'latest',
       }
-      if $::osfamily == 'RedHat' {
+      if $facts['os']['family'] == 'RedHat' {
         if $::operatingsystemmajrelease == '5' {
           class { 'epel':
             epel_baseurl => "http://osmirror.delivery.puppetlabs.net/epel${::operatingsystemmajrelease}-\\$basearch/RPMS.all",

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -29,10 +29,10 @@ RSpec.configure do |c|
         ensure   => 'latest',
       }
       if $facts['os']['family'] == 'RedHat' {
-        if $::operatingsystemmajrelease == '5' {
+        if $facts['os']['release']['major'] == '5' {
           class { 'epel':
-            epel_baseurl => "http://osmirror.delivery.puppetlabs.net/epel${::operatingsystemmajrelease}-\\$basearch/RPMS.all",
-            epel_mirrorlist => "http://osmirror.delivery.puppetlabs.net/epel${::operatingsystemmajrelease}-\\$basearch/RPMS.all",
+            epel_baseurl => "http://osmirror.delivery.puppetlabs.net/epel${facts['os']['release']['major']}-\\$basearch/RPMS.all",
+            epel_mirrorlist => "http://osmirror.delivery.puppetlabs.net/epel${facts['os']['release']['major']}-\\$basearch/RPMS.all",
           }
         } else {
           class { 'epel': }


### PR DESCRIPTION
Puppet 8 will default to not send legacy facts. Update the module so that it uses the facts that superseded these legacy facts.
