### PR TITLE
(CONT-802) - Revert RSpec/NoExpectationExample

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,6 +17,14 @@ RSpec/ExampleLength:
 RSpec/NamedSubject:
   Enabled: false
 
+RSpec/NoExpectationExample:
+  Exclude:
+    - 'spec/acceptance/acceptance_1_readme_spec.rb'
+    - 'spec/acceptance/acceptance_1b_spec.rb'
+    - 'spec/acceptance/acceptance_2b_spec.rb'
+    - 'spec/acceptance/acceptance_3b_spec.rb'
+    - 'spec/acceptance/acceptance_4b_spec.rb'
+
 # Offense count: 4
 RSpec/RepeatedExampleGroupBody:
   Exclude:

--- a/spec/acceptance/acceptance_1_readme_spec.rb
+++ b/spec/acceptance/acceptance_1_readme_spec.rb
@@ -26,7 +26,7 @@ describe 'README examples', unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { idempotent_apply(pp) }.not_to raise_error
+      idempotent_apply(pp)
       run_shell('sleep 15')
     end
 
@@ -67,7 +67,7 @@ describe 'README examples', unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
       run_shell('sleep 15')
     end
 

--- a/spec/acceptance/acceptance_1b_spec.rb
+++ b/spec/acceptance/acceptance_1b_spec.rb
@@ -119,7 +119,7 @@ describe 'Acceptance case one', unless: stop_test do
           value => $java_home,
         }
       MANIFEST
-      expect { idempotent_apply(pp) }.not_to raise_error
+      idempotent_apply(pp)
     end
 
     it 'is serving a page on port 80', retry: 5, retry_wait: 10 do
@@ -149,7 +149,7 @@ describe 'Acceptance case one', unless: stop_test do
           user           => 'tomcat8',
         }
       MANIFEST
-      expect { apply_manifest(pp) }.not_to raise_error
+      apply_manifest(pp)
     end
 
     it 'is not serving a page on port 80', retry: 5, retry_wait: 10 do
@@ -173,7 +173,7 @@ describe 'Acceptance case one', unless: stop_test do
           user           => 'tomcat8',
         }
       MANIFEST
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'is serving a page on port 80', retry: 5, retry_wait: 10 do
@@ -192,7 +192,7 @@ describe 'Acceptance case one', unless: stop_test do
           war_ensure    => absent,
         }
       MANIFEST
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'does not have deployed the war', retry: 5, retry_wait: 10 do
@@ -222,7 +222,7 @@ describe 'Acceptance case one', unless: stop_test do
           user           => 'tomcat8',
         }
       MANIFEST
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'is not able to serve pages over port 80', retry: 5, retry_wait: 10 do

--- a/spec/acceptance/acceptance_2b_spec.rb
+++ b/spec/acceptance/acceptance_2b_spec.rb
@@ -150,7 +150,7 @@ describe 'Two different installations with two instances each of Tomcat 8 in the
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { idempotent_apply(pp) }.not_to raise_error
+      idempotent_apply(pp)
     end
 
     # test the war
@@ -203,7 +203,7 @@ describe 'Two different installations with two instances each of Tomcat 8 in the
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'tomcat8-first should not be serving a page on port 8280', retry: 10, retry_wait: 10 do
@@ -257,7 +257,7 @@ describe 'Two different installations with two instances each of Tomcat 8 in the
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'tomcat8-first should not display message when war is not deployed', retry: 10, retry_wait: 10 do
@@ -301,7 +301,7 @@ describe 'Two different installations with two instances each of Tomcat 8 in the
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'tomcat8 should be serving a war on port 8280', retry: 10, retry_wait: 10 do

--- a/spec/acceptance/acceptance_3b_spec.rb
+++ b/spec/acceptance/acceptance_3b_spec.rb
@@ -56,7 +56,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { idempotent_apply(pp) }.not_to raise_error
+      idempotent_apply(pp)
     end
 
     it 'is serving a page on port 8180', retry: 5, retry_wait: 10 do
@@ -81,7 +81,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'is not serving a page on port 8180', retry: 5, retry_wait: 10 do
@@ -100,7 +100,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'is serving a page on port 8180', retry: 5, retry_wait: 10 do
@@ -119,7 +119,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'does not have deployed the war', retry: 5, retry_wait: 10 do
@@ -143,7 +143,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'is not able to serve pages over port 8180', retry: 5, retry_wait: 10 do
@@ -164,7 +164,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'shoud have a service named FooBar and a class names FooBar' do
@@ -182,7 +182,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'has changed the conf.xml file' do
@@ -201,7 +201,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'has changed the conf.xml file' do
@@ -222,7 +222,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest to create the engine without error' do
-      expect { apply_manifest(pp_one, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp_one, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'has changed the conf.xml file #5' do
@@ -243,7 +243,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest to change the settings without error' do
-      expect { apply_manifest(pp_two, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp_two, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'has changed the conf.xml file #999' do
@@ -268,7 +268,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest to create the engine without error' do
-      expect { apply_manifest(pp_one, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp_one, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     # validation
@@ -295,7 +295,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest to remove a engine attribute without error' do
-      expect { apply_manifest(pp_two, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp_two, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'has changed the conf.xml file #seperated' do
@@ -316,7 +316,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'has changed the context.xml file' do
@@ -339,7 +339,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'has changed the context.xml file' do
@@ -379,7 +379,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'has changed the context.xml file' do
@@ -403,7 +403,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'has changed the context.xml file' do
@@ -435,7 +435,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'has changed the context.xml file' do

--- a/spec/acceptance/acceptance_4b_spec.rb
+++ b/spec/acceptance/acceptance_4b_spec.rb
@@ -77,7 +77,7 @@ describe 'Use two realms within a configuration', docker: true, unless: stop_tes
       }
     MANIFEST
     it 'applies the manifest without error' do
-      expect { apply_manifest(pp_one, catch_failures: true, acceptable_exit_codes: [0, 2]) }.not_to raise_error
+      apply_manifest(pp_one, catch_failures: true, acceptable_exit_codes: [0, 2])
     end
 
     it 'contains two realms in config file', retry: 5, retry_wait: 10 do
@@ -119,7 +119,7 @@ describe 'Use two realms within a configuration', docker: true, unless: stop_tes
       }
     MANIFEST
     it 'is idempotent' do
-      expect { idempotent_apply(pp_two) }.not_to raise_error
+      idempotent_apply(pp_two)
     end
   end
 end


### PR DESCRIPTION
During the work to add support for puppet 8, a rubocop violation "RSpec/NoExpectationExample" was fixed.

This included adding an expect {} block around puppet applys, which initially seemed to work as expected.

However it was discovered that this hid error outputs of failed runs, meaning debugging was impossible.
This PR reverts these changes (f375607) and adds the cop back to the "todo".