### PR TITLE
(MAINT) Bumping Daemon Version to latest (1.3.4)

### DIFF
--- a/spec/acceptance/acceptance_1b_spec.rb
+++ b/spec/acceptance/acceptance_1b_spec.rb
@@ -27,7 +27,7 @@ describe 'Acceptance case one', unless: stop_test do
     end
   end
 
-  let(:daemon_version) { '1.3.3' }
+  let(:daemon_version) { '1.3.4' }
 
   context 'Initial install Tomcat and verification' do
     it 'applies the manifest without error' do


### PR DESCRIPTION
Prior to this commit, our CI was failing across our nightlies. This update aims to bump a test dependency to check whether it has any impact on the current issues.