### PR TITLE
Update var types

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -47,6 +47,10 @@
 * `tomcat::instance::copy_from_home`: Private define to copy a conf file from catalina_home to catalina_base
 * `tomcat::instance::dependencies`
 
+### Functions
+
+* [`tomcat::change`](#tomcat--change): This function exists for usage of a returning the input params that is a deferred function Will be used for deferring the values at agent lev
+
 ## Classes
 
 ### <a name="tomcat"></a>`tomcat`
@@ -879,7 +883,7 @@ The following parameters are available in the `tomcat::config::server::connector
 
 ##### <a name="-tomcat--config--server--connector--catalina_base"></a>`catalina_base`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Specifies the base directory of the Tomcat installation to manage. Valid options: a string containing an absolute path.
 
@@ -895,7 +899,7 @@ Default value: `'present'`
 
 ##### <a name="-tomcat--config--server--connector--port"></a>`port`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Variant[String[1], Stdlib::Port]]`
 
 Sets a TCP port on which to create a server socket. Maps to the [port XML attribute](http://tomcat.apache.org/tomcat-8.0-doc/config/http.html#Common_Attributes). Valid options: a string.
 
@@ -947,7 +951,7 @@ Default value: `undef`
 
 ##### <a name="-tomcat--config--server--connector--server_config"></a>`server_config`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
 
@@ -1046,7 +1050,7 @@ Default value: `[]`
 
 ##### <a name="-tomcat--config--server--context--server_config"></a>`server_config`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
 
@@ -1180,7 +1184,7 @@ Default value: `'present'`
 
 ##### <a name="-tomcat--config--server--engine--server_config"></a>`server_config`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
 
@@ -1261,7 +1265,7 @@ Default value: `[]`
 
 ##### <a name="-tomcat--config--server--globalnamingresource--server_config"></a>`server_config`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
 
@@ -1352,7 +1356,7 @@ Default value: `[]`
 
 ##### <a name="-tomcat--config--server--host--server_config"></a>`server_config`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
 
@@ -1459,7 +1463,7 @@ Default value: `[]`
 
 ##### <a name="-tomcat--config--server--listener--server_config"></a>`server_config`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
 
@@ -1581,7 +1585,7 @@ Default value: `undef`
 
 ##### <a name="-tomcat--config--server--realm--server_config"></a>`server_config`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
 
@@ -1680,7 +1684,7 @@ Default value: `[]`
 
 ##### <a name="-tomcat--config--server--resources--server_config"></a>`server_config`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
 
@@ -1743,7 +1747,7 @@ Default value: `'present'`
 
 ##### <a name="-tomcat--config--server--service--server_config"></a>`server_config`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
 
@@ -1959,7 +1963,7 @@ Default value: `[]`
 
 ##### <a name="-tomcat--config--server--valve--server_config"></a>`server_config`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
 
@@ -2722,4 +2726,26 @@ Data type: `String[1]`
 The 'group' owner of the tomcat war file.
 
 Default value: `'tomcat'`
+
+## Functions
+
+### <a name="tomcat--change"></a>`tomcat::change`
+
+Type: Ruby 4.x API
+
+This function exists for usage of a returning the input params that is a deferred function
+Will be used for deferring the values at agent level
+
+#### `tomcat::change(Any $arg)`
+
+This function exists for usage of a returning the input params that is a deferred function
+Will be used for deferring the values at agent level
+
+Returns: `Any`
+
+##### `arg`
+
+Data type: `Any`
+
+
 

--- a/manifests/config/server/connector.pp
+++ b/manifests/config/server/connector.pp
@@ -24,16 +24,16 @@
 #   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::connector (
-  Optional[String[1]] $catalina_base         = undef,
-  Enum['present','absent'] $connector_ensure = 'present',
-  Optional[String[1]] $port                  = undef,
-  String[1] $protocol                        = $name,
-  String[1] $parent_service                  = 'Catalina',
-  Hash $additional_attributes                = {},
-  Array $attributes_to_remove                = [],
-  Optional[Boolean] $purge_connectors        = undef,
-  Optional[String[1]] $server_config         = undef,
-  Boolean $show_diff                         = true,
+  Optional[Stdlib::Absolutepath]             $catalina_base         = undef,
+  Enum['present','absent']                   $connector_ensure      = 'present',
+  Optional[Variant[String[1], Stdlib::Port]] $port                  = undef,
+  String[1]                                  $protocol              = $name,
+  String[1]                                  $parent_service        = 'Catalina',
+  Hash                                       $additional_attributes = {},
+  Array                                      $attributes_to_remove  = [],
+  Optional[Boolean]                          $purge_connectors      = undef,
+  Optional[Stdlib::Absolutepath]             $server_config         = undef,
+  Boolean                                    $show_diff             = true,
 ) {
   include tomcat
   $_catalina_base = pick($catalina_base, $tomcat::catalina_home)
@@ -56,7 +56,7 @@ define tomcat::config::server::connector (
   }
 
   if $_purge_connectors and ($connector_ensure == 'absent') {
-    fail('$connector_ensure must be set to \'true\' or \'present\' to use $purge_connectors')
+    fail('$connector_ensure must be set to \'present\' to use $purge_connectors')
   }
 
   if $server_config {

--- a/manifests/config/server/context.pp
+++ b/manifests/config/server/context.pp
@@ -30,7 +30,7 @@ define tomcat::config::server::context (
   Optional[String[1]]            $parent_host           = undef,
   Hash                           $additional_attributes = {},
   Array                          $attributes_to_remove  = [],
-  Optional[String[1]]            $server_config         = undef,
+  Optional[Stdlib::Absolutepath] $server_config         = undef,
   Boolean                        $show_diff             = true,
 ) {
   include tomcat

--- a/manifests/config/server/engine.pp
+++ b/manifests/config/server/engine.pp
@@ -31,20 +31,20 @@
 #   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::engine (
-  String[1] $default_host,
-  Optional[Stdlib::Absolutepath] $catalina_base                     = undef,
-  Optional[Variant[Integer, String[1]]] $background_processor_delay = undef,
-  Enum['present','absent'] $background_processor_delay_ensure       = 'present',
-  Optional[String[1]] $class_name                                   = undef,
-  Enum['present','absent'] $class_name_ensure                       = 'present',
-  Optional[String[1]] $engine_name                                  = undef,
-  Optional[String[1]] $jvm_route                                    = undef,
-  Enum['present','absent'] $jvm_route_ensure                        = 'present',
-  String[1] $parent_service                                         = 'Catalina',
-  Optional[Variant[String[1], Integer]] $start_stop_threads         = undef,
-  Enum['present','absent'] $start_stop_threads_ensure               = 'present',
-  Optional[String[1]] $server_config                                = undef,
-  Boolean $show_diff                                                = true,
+  String[1]                             $default_host,
+  Optional[Stdlib::Absolutepath]        $catalina_base                     = undef,
+  Optional[Variant[Integer, String[1]]] $background_processor_delay        = undef,
+  Enum['present','absent']              $background_processor_delay_ensure = 'present',
+  Optional[String[1]]                   $class_name                        = undef,
+  Enum['present','absent']              $class_name_ensure                 = 'present',
+  Optional[String[1]]                   $engine_name                       = undef,
+  Optional[String[1]]                   $jvm_route                         = undef,
+  Enum['present','absent']              $jvm_route_ensure                  = 'present',
+  String[1]                             $parent_service                    = 'Catalina',
+  Optional[Variant[String[1], Integer]] $start_stop_threads                = undef,
+  Enum['present','absent']              $start_stop_threads_ensure         = 'present',
+  Optional[Stdlib::Absolutepath]        $server_config                     = undef,
+  Boolean                               $show_diff                         = true,
 ) {
   include tomcat
   $_catalina_base = pick($catalina_base, $tomcat::catalina_home)

--- a/manifests/config/server/globalnamingresource.pp
+++ b/manifests/config/server/globalnamingresource.pp
@@ -18,14 +18,14 @@
 #   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::globalnamingresource (
-  Stdlib::Absolutepath $catalina_base = $tomcat::catalina_home,
-  Optional[String[1]] $resource_name  = undef,
-  String[1] $type                     = 'Resource',
-  Enum['present','absent'] $ensure    = 'present',
-  Hash $additional_attributes         = {},
-  Array $attributes_to_remove         = [],
-  Optional[String[1]] $server_config  = undef,
-  Boolean $show_diff                  = true,
+  Stdlib::Absolutepath           $catalina_base         = $tomcat::catalina_home,
+  Optional[String[1]]            $resource_name         = undef,
+  String[1]                      $type                  = 'Resource',
+  Enum['present','absent']       $ensure                = 'present',
+  Hash                           $additional_attributes = {},
+  Array                          $attributes_to_remove  = [],
+  Optional[Stdlib::Absolutepath] $server_config         = undef,
+  Boolean                        $show_diff             = true,
 ) {
   if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')

--- a/manifests/config/server/host.pp
+++ b/manifests/config/server/host.pp
@@ -22,16 +22,16 @@
 #   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::host (
-  Optional[String[1]] $app_base                 = undef,
-  Optional[Stdlib::Absolutepath] $catalina_base = undef,
-  Enum['present','absent'] $host_ensure         = 'present',
-  Optional[String[1]] $host_name                = undef,
-  String $parent_service                        = 'Catalina',
-  Hash $additional_attributes                   = {},
-  Array $attributes_to_remove                   = [],
-  Optional[String[1]] $server_config            = undef,
-  Optional[Array] $aliases                      = undef,
-  Boolean $show_diff                            = true,
+  Optional[String[1]]            $app_base              = undef,
+  Optional[Stdlib::Absolutepath] $catalina_base         = undef,
+  Enum['present','absent']       $host_ensure           = 'present',
+  Optional[String[1]]            $host_name             = undef,
+  String                         $parent_service        = 'Catalina',
+  Hash                           $additional_attributes = {},
+  Array                          $attributes_to_remove  = [],
+  Optional[Stdlib::Absolutepath] $server_config         = undef,
+  Optional[Array]                $aliases               = undef,
+  Boolean                        $show_diff             = true,
 ) {
   include tomcat
   $_catalina_base = pick($catalina_base, $tomcat::catalina_home)

--- a/manifests/config/server/listener.pp
+++ b/manifests/config/server/listener.pp
@@ -22,16 +22,16 @@
 #   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::listener (
-  Stdlib::Absolutepath $catalina_base       = $tomcat::catalina_home,
-  Enum['present','absent'] $listener_ensure = 'present',
-  Optional[String[1]] $class_name           = undef,
-  Optional[String[1]] $parent_service       = undef,
-  Optional[String[1]] $parent_engine        = undef,
-  Optional[String[1]] $parent_host          = undef,
-  Hash $additional_attributes               = {},
-  Array $attributes_to_remove               = [],
-  Optional[String[1]] $server_config        = undef,
-  Boolean $show_diff                        = true,
+  Stdlib::Absolutepath           $catalina_base         = $tomcat::catalina_home,
+  Enum['present','absent']       $listener_ensure       = 'present',
+  Optional[String[1]]            $class_name            = undef,
+  Optional[String[1]]            $parent_service        = undef,
+  Optional[String[1]]            $parent_engine         = undef,
+  Optional[String[1]]            $parent_host           = undef,
+  Hash                           $additional_attributes = {},
+  Array                          $attributes_to_remove  = [],
+  Optional[Stdlib::Absolutepath] $server_config         = undef,
+  Boolean                        $show_diff             = true,
 ) {
   if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
     fail('Server configurations require Augeas >= 1.0.0')

--- a/manifests/config/server/realm.pp
+++ b/manifests/config/server/realm.pp
@@ -28,18 +28,18 @@
 #   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
 #
 define tomcat::config::server::realm (
-  Optional[String[1]] $catalina_base      = undef,
-  String[1] $class_name                   = $name,
-  Enum['present','absent'] $realm_ensure  = 'present',
-  String $parent_service                  = 'Catalina',
-  String $parent_engine                   = 'Catalina',
-  Optional[String[1]] $parent_host        = undef,
-  Optional[String[1]] $parent_realm       = undef,
-  Hash $additional_attributes             = {},
-  Array $attributes_to_remove             = [],
-  Optional[Boolean] $purge_realms         = undef,
-  Optional[String[1]] $server_config      = undef,
-  Boolean $show_diff                      = true,
+  Optional[String[1]]            $catalina_base         = undef,
+  String[1]                      $class_name            = $name,
+  Enum['present','absent']       $realm_ensure          = 'present',
+  String                         $parent_service        = 'Catalina',
+  String                         $parent_engine         = 'Catalina',
+  Optional[String[1]]            $parent_host           = undef,
+  Optional[String[1]]            $parent_realm          = undef,
+  Hash                           $additional_attributes = {},
+  Array                          $attributes_to_remove  = [],
+  Optional[Boolean]              $purge_realms          = undef,
+  Optional[Stdlib::Absolutepath] $server_config         = undef,
+  Boolean                        $show_diff             = true,
 ) {
   include tomcat
   $_catalina_base = pick($catalina_base, $tomcat::catalina_home)

--- a/manifests/config/server/resources.pp
+++ b/manifests/config/server/resources.pp
@@ -30,7 +30,7 @@ define tomcat::config::server::resources (
   Optional[String[1]]            $parent_context        = undef,
   Hash                           $additional_attributes = {},
   Array[String[1]]               $attributes_to_remove  = [],
-  Optional[String[1]]            $server_config         = undef,
+  Optional[Stdlib::Absolutepath] $server_config         = undef,
   Boolean                        $show_diff             = true,
 ) {
   include tomcat

--- a/manifests/config/server/service.pp
+++ b/manifests/config/server/service.pp
@@ -18,7 +18,7 @@ define tomcat::config::server::service (
   Optional[String[1]]            $class_name        = undef,
   Enum['present','absent']       $class_name_ensure = 'present',
   Enum['present','absent']       $service_ensure    = 'present',
-  Optional[String[1]]            $server_config     = undef,
+  Optional[Stdlib::Absolutepath] $server_config     = undef,
   Boolean                        $show_diff         = true,
 ) {
   include tomcat

--- a/manifests/config/server/valve.pp
+++ b/manifests/config/server/valve.pp
@@ -33,7 +33,7 @@ define tomcat::config::server::valve (
   Hash                           $additional_attributes = {},
   Array                          $attributes_to_remove  = [],
   Array                          $uniqueness_attributes = [],
-  Optional[String[1]]            $server_config         = undef,
+  Optional[Stdlib::Absolutepath] $server_config         = undef,
   Boolean                        $show_diff             = true,
 ) {
   include tomcat

--- a/spec/acceptance/acceptance_1b_spec.rb
+++ b/spec/acceptance/acceptance_1b_spec.rb
@@ -103,7 +103,7 @@ describe 'Acceptance case one', unless: stop_test do
         }
         tomcat::config::server::connector { 'tomcat8-ajp':
           catalina_base         => '/opt/apache-tomcat/tomcat8-jsvc',
-          connector_ensure      => absent,
+          connector_ensure      => 'absent',
           port                  => '8309',
         }
         tomcat::war { 'war_one.war':

--- a/spec/acceptance/acceptance_3b_spec.rb
+++ b/spec/acceptance/acceptance_3b_spec.rb
@@ -132,7 +132,7 @@ describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
   context 'remove the connector' do
     pp = <<-MANIFEST
       tomcat::config::server::connector { 'tomcat8-http':
-        connector_ensure => absent,
+        connector_ensure => 'absent',
         catalina_base    => '/opt/apache-tomcat8/tomcat8',
         port             => '8180',
         notify           => Tomcat::Service['tomcat8'],

--- a/spec/defines/config/server/connector_spec.rb
+++ b/spec/defines/config/server/connector_spec.rb
@@ -122,22 +122,6 @@ describe 'tomcat::config::server::connector', type: :define do
     }
   end
 
-  context 'remove connector with purge_connectors' do
-    let :params do
-      {
-        catalina_base: 'opt/apache-tomcat/test',
-        connector_ensure: 'absent',
-        purge_connectors: true
-      }
-    end
-
-    it do
-      expect {
-        catalogue
-      }.to raise_error(Puppet::Error, %r{\$connector_ensure must be set to 'true' or 'present' to use \$purge_connectors})
-    end
-  end
-
   context 'two connectors with same protocol' do
     let :pre_condition do
       'class { "tomcat": }
@@ -157,6 +141,21 @@ describe 'tomcat::config::server::connector', type: :define do
   end
 
   describe 'failing tests' do
+    context 'remove connector with purge_connectors' do
+      let :params do
+        {
+          connector_ensure: 'absent',
+          purge_connectors: true
+        }
+      end
+
+      it do
+        expect {
+          catalogue
+        }.to raise_error(Puppet::Error, %r{\$connector_ensure must be set to 'present' to use \$purge_connectors})
+      end
+    end
+
     context 'bad connector_ensure' do
       let :params do
         {


### PR DESCRIPTION
## Summary
This PR mainly focuses on providing a better var type to match the description of the parameters

## Additional Context
I was getting an error on my puppet runs:
Error while evaluating a Resource Statement:

Tomcat::Config::Server::Connector[tomcat-app-http]: parameter 'port' expects a value of type Undef or String, got Integer

…in …/labo/modules/profile/manifests/tomcat.pp, line: 117.

## Checklist
Verified by pinning my branch and running puppet