### PR TITLE
[CAT-1382] : Fixing CI failure due to rubocop

### DIFF
--- a/spec/acceptance/acceptance_2b_spec.rb
+++ b/spec/acceptance/acceptance_2b_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-describe 'Two different installations with two instances each of Tomcat 8 in the same manifest', docker: true do
+describe 'Two different installations with two instances each of Tomcat 8 in the same manifest', :docker do
   after :all do
     run_shell('pkill -f tomcat', expect_failures: true)
     run_shell('rm -rf /opt/tomcat*', expect_failures: true)

--- a/spec/acceptance/acceptance_3b_spec.rb
+++ b/spec/acceptance/acceptance_3b_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 
 stop_test = SKIP_TOMCAT_8
 
-describe 'Tomcat Install source -defaults', docker: true, unless: stop_test do
+describe 'Tomcat Install source -defaults', :docker, unless: stop_test do
   after :all do
     run_shell('pkill -f tomcat', expect_failures: true)
     run_shell('rm -rf /opt/tomcat*', expect_failures: true)

--- a/spec/acceptance/acceptance_4b_spec.rb
+++ b/spec/acceptance/acceptance_4b_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 
 stop_test = SKIP_TOMCAT_8
 
-describe 'Use two realms within a configuration', docker: true, unless: stop_test do
+describe 'Use two realms within a configuration', :docker, unless: stop_test do
   after :all do
     run_shell('pkill -f tomcat', expect_failures: true)
     run_shell('rm -rf /opt/tomcat*', expect_failures: true)


### PR DESCRIPTION
## Summary
Fixing CI failure due to rubocop

## Additional Context
- [x] New version released in rubocop-rspec ([v2.24.0](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.24.0)) caused regression in linting.
```
Add RSpec/MetadataStyle and RSpec/EmptyMetadata cops.
```


## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)