### PR TITLE
(CAT-1599) - Fixing facts issue with Puppet 8 while running spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,5 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     secrets: "inherit"
+    with:
+      runs_on: "ubuntu-20.04"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,4 +14,5 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     secrets: "inherit"
-
+    with:
+      runs_on: "ubuntu-20.04"

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -8,7 +8,14 @@ describe 'tomcat::service', type: :define do
   end
   let :facts do
     {
-      os: { family: 'Debian' }
+      os: {
+        architecture: 'amd64',
+        family: 'Debian',
+        hardware: 'x86_64',
+        name: 'Debian',
+        release: { full: '11.1', major: '11', minor: '1' },
+        selinux: { enabled: false }
+      }
     }
   end
   let :title do


### PR DESCRIPTION
## Summary

With Puppet 8 the spec fails due to missing `name` field under `os`, which I have added and it works fine with 8.


## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)