### PR TITLE
Adding support for sslhostconfig options

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ tomcat::instance { 'my_tomcat_app':
     port                  => $https_port,
     protocol              => $http_version,
     purge_connectors      => true,
+    cert_key_file         => '/path/to/key.pem',
+    cert_file             => '/path/to/cert.pem',
+    cert_chain_file       => '/path/to/chain.pem',
+    cert_type             => 'RSA',
     additional_attributes => {
       'SSLEnabled'          => bool2str($https_enabled),
       'maxThreads'          => $https_connector_max_threads,

--- a/manifests/config/server/connector.pp
+++ b/manifests/config/server/connector.pp
@@ -103,13 +103,14 @@ define tomcat::config::server::connector (
       $sslhostconfig_path = "Server/Service/Connector[#attribute/port='${port}']"
 
       $_sslhostconfig_changes = [
-        "set ${sslhostconfig_path}/Certificate/#attribute/certificateKeyFile ${cert_key_file}",
-        "set ${sslhostconfig_path}/Certificate/#attribute/certificateFile ${cert_file}",
-        "set ${sslhostconfig_path}/Certificate/#attribute/certificateChainFile ${cert_chain_file}",
-        "set ${sslhostconfig_path}/Certificate/#attribute/type ${cert_type}",
+        "set ${sslhostconfig_path}/SSLHostConfig/Certificate/#attribute/certificateKeyFile ${cert_key_file}",
+        "set ${sslhostconfig_path}/SSLHostConfig/Certificate/#attribute/certificateFile ${cert_file}",
+        "set ${sslhostconfig_path}/SSLHostConfig/Certificate/#attribute/certificateChainFile ${cert_chain_file}",
+        "set ${sslhostconfig_path}/SSLHostConfig/Certificate/#attribute/type ${cert_type}",
       ]
     } else {
       $_sslhostconfig_changes = undef
+      notice('No certificate parameters provided, skipping SSLHostConfig configuration')
     }
 
     if ! empty(any2array($attributes_to_remove)) {

--- a/manifests/config/server/connector.pp
+++ b/manifests/config/server/connector.pp
@@ -110,7 +110,6 @@ define tomcat::config::server::connector (
       ]
     } else {
       $_sslhostconfig_changes = undef
-      notice('No certificate parameters provided, skipping SSLHostConfig configuration')
     }
 
     if ! empty(any2array($attributes_to_remove)) {

--- a/manifests/config/server/connector.pp
+++ b/manifests/config/server/connector.pp
@@ -22,6 +22,14 @@
 #   Specifies a server.xml file to manage. Valid options: a string containing an absolute path.
 # @param show_diff
 #   Specifies display differences when augeas changes files, defaulting to true. Valid options: true or false.
+# @param cert_key_file
+#   Specifies the path to the private key file. Valid options: a string containing an absolute path.
+# @param cert_file
+#   Specifies the path to the certificate file. Valid options: a string containing an absolute path.
+# @param cert_chain_file
+#   Specifies the path to the certificate chain file. Valid options: a string containing an absolute path.
+# @param cert_type
+#   Specifies the type of certificate. Valid options: a string. 'RSA'.
 #
 define tomcat::config::server::connector (
   Optional[Stdlib::Absolutepath]             $catalina_base         = undef,
@@ -34,6 +42,10 @@ define tomcat::config::server::connector (
   Optional[Boolean]                          $purge_connectors      = undef,
   Optional[Stdlib::Absolutepath]             $server_config         = undef,
   Boolean                                    $show_diff             = true,
+  Optional[Stdlib::Absolutepath]             $cert_key_file         = undef,
+  Optional[Stdlib::Absolutepath]             $cert_file             = undef,
+  Optional[Stdlib::Absolutepath]             $cert_chain_file       = undef,
+  String[1]                                  $cert_type             = 'RSA',
 ) {
   include tomcat
   $_catalina_base = pick($catalina_base, $tomcat::catalina_home)
@@ -85,6 +97,21 @@ define tomcat::config::server::connector (
     } else {
       $_additional_attributes = undef
     }
+
+    # Add SSLHostConfig if certificate parameters are provided
+    if $cert_key_file and $cert_file and $cert_chain_file {
+      $sslhostconfig_path = "Server/Service/Connector[#attribute/port='${port}']"
+
+      $_sslhostconfig_changes = [
+        "set ${sslhostconfig_path}/Certificate/#attribute/certificateKeyFile ${cert_key_file}",
+        "set ${sslhostconfig_path}/Certificate/#attribute/certificateFile ${cert_file}",
+        "set ${sslhostconfig_path}/Certificate/#attribute/certificateChainFile ${cert_chain_file}",
+        "set ${sslhostconfig_path}/Certificate/#attribute/type ${cert_type}",
+      ]
+    } else {
+      $_sslhostconfig_changes = undef
+    }
+
     if ! empty(any2array($attributes_to_remove)) {
       $_attributes_to_remove = prefix(any2array($attributes_to_remove), "rm ${base_path}/#attribute/")
     } else {
@@ -97,6 +124,7 @@ define tomcat::config::server::connector (
           $_protocol_change,
           $_additional_attributes,
           $_attributes_to_remove,
+          $_sslhostconfig_changes,
     ]))
   }
 

--- a/spec/defines/config/server/connector_spec.rb
+++ b/spec/defines/config/server/connector_spec.rb
@@ -38,10 +38,10 @@ describe 'tomcat::config::server::connector', type: :define do
     end
 
     sslhostconfig_changes = [
-      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/certificateKeyFile /path/to/cert.key",
-      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/certificateFile /path/to/cert.pem",
-      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/certificateChainFile /path/to/chain.pem",
-      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/type RSA",
+      "set Server/Service/Connector[#attribute/port='8180']/SSLHostConfig/Certificate/#attribute/certificateKeyFile /path/to/cert.key",
+      "set Server/Service/Connector[#attribute/port='8180']/SSLHostConfig/Certificate/#attribute/certificateFile /path/to/cert.pem",
+      "set Server/Service/Connector[#attribute/port='8180']/SSLHostConfig/Certificate/#attribute/certificateChainFile /path/to/chain.pem",
+      "set Server/Service/Connector[#attribute/port='8180']/SSLHostConfig/Certificate/#attribute/type RSA",
     ]
 
     changes = [
@@ -85,10 +85,10 @@ describe 'tomcat::config::server::connector', type: :define do
     end
 
     sslhostconfig_changes = [
-      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/certificateKeyFile /path/to/cert.key",
-      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/certificateFile /path/to/cert.pem",
-      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/certificateChainFile /path/to/chain.pem",
-      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/type RSA",
+      "set Server/Service/Connector[#attribute/port='8180']/SSLHostConfig/Certificate/#attribute/certificateKeyFile /path/to/cert.key",
+      "set Server/Service/Connector[#attribute/port='8180']/SSLHostConfig/Certificate/#attribute/certificateFile /path/to/cert.pem",
+      "set Server/Service/Connector[#attribute/port='8180']/SSLHostConfig/Certificate/#attribute/certificateChainFile /path/to/chain.pem",
+      "set Server/Service/Connector[#attribute/port='8180']/SSLHostConfig/Certificate/#attribute/type RSA",
     ]
 
     changes = [

--- a/spec/defines/config/server/connector_spec.rb
+++ b/spec/defines/config/server/connector_spec.rb
@@ -29,9 +29,20 @@ describe 'tomcat::config::server::connector', type: :define do
           'connectionTimeout' => '20000',
           'spaces' => 'foo bar'
         },
-        attributes_to_remove: ['foo', 'bar', 'baz']
+        attributes_to_remove: ['foo', 'bar', 'baz'],
+        cert_key_file: '/path/to/cert.key',
+        cert_file: '/path/to/cert.pem',
+        cert_chain_file: '/path/to/chain.pem',
+        cert_type: 'RSA'
       }
     end
+
+    sslhostconfig_changes = [
+      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/certificateKeyFile /path/to/cert.key",
+      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/certificateFile /path/to/cert.pem",
+      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/certificateChainFile /path/to/chain.pem",
+      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/type RSA",
+    ]
 
     changes = [
       'set Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/port 8180',
@@ -42,7 +53,8 @@ describe 'tomcat::config::server::connector', type: :define do
       'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/foo',
       'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/bar',
       'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/baz',
-    ]
+    ].concat(sslhostconfig_changes)
+
     it {
       expect(subject).to contain_augeas('server-/opt/apache-tomcat/test-Catalina2-connector-8180').with(
         'lens' => 'Xml.lns',
@@ -64,9 +76,20 @@ describe 'tomcat::config::server::connector', type: :define do
           'redirectPort' => '8543',
           'connectionTimeout' => '20000'
         },
-        attributes_to_remove: ['foo', 'bar', 'baz']
+        attributes_to_remove: ['foo', 'bar', 'baz'],
+        cert_key_file: '/path/to/cert.key',
+        cert_file: '/path/to/cert.pem',
+        cert_chain_file: '/path/to/chain.pem',
+        cert_type: 'RSA'
       }
     end
+
+    sslhostconfig_changes = [
+      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/certificateKeyFile /path/to/cert.key",
+      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/certificateFile /path/to/cert.pem",
+      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/certificateChainFile /path/to/chain.pem",
+      "set Server/Service/Connector[#attribute/port='8180']/Certificate/#attribute/type RSA",
+    ]
 
     changes = [
       'rm Server//Connector[#attribute/protocol=\'AJP/1.3\'][#attribute/port!=\'8180\']',
@@ -77,7 +100,8 @@ describe 'tomcat::config::server::connector', type: :define do
       'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/foo',
       'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/bar',
       'rm Server/Service[#attribute/name=\'Catalina2\']/Connector[#attribute/port=\'8180\']/#attribute/baz',
-    ]
+    ].concat(sslhostconfig_changes)
+
     it {
       expect(subject).to contain_augeas('server-/opt/apache-tomcat/test-Catalina2-connector-8180').with(
         'lens' => 'Xml.lns',


### PR DESCRIPTION
## Summary
Adding support for sslhostconfig options.
```
 <SSLHostConfig>
    <Certificate
        certificateKeyFile="conf/localhost-rsa-key.pem"
        certificateFile="conf/localhost-rsa-cert.pem"
        certificateChainFile="conf/localhost-rsa-chain.pem"
        type="RSA"
        />
  </SSLHostConfig>
```

read more about it in tomcat  [docs](https://tomcat.apache.org/tomcat-10.1-doc/ssl-howto.html#Edit_the_Tomcat_Configuration_File)

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)