### PR TITLE
fix(MODULES-11856): Raise puppetlabs/concat upper version bound to 11.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.0.0 < 10.0.0"
+      "version_requirement": ">= 4.0.0 < 11.0.0"
     },
     {
       "name": "puppet/archive",

--- a/spec/acceptance/acceptance_1b_spec.rb
+++ b/spec/acceptance/acceptance_1b_spec.rb
@@ -34,7 +34,7 @@ describe 'Acceptance case one', unless: stop_test do
   # If it then shows an error regarding the commons-daemon-<daemon_version>-native-src
   #   update the daemon_version variable below to match the version found by navigating to
   #   /opt/apache-tomcat/bin/ and checking the shipped version of commons-daemon-native-src.
-  let(:daemon_version) { '1.4.1' }
+  let(:daemon_version) { '1.6.1' }
 
   context 'Initial install Tomcat and verification' do
     it 'applies the manifest without error' do


### PR DESCRIPTION

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
